### PR TITLE
Add the ability to specify client-side private key password

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -195,10 +195,11 @@ module HTTParty
     #
     #   class Foo
     #     include HTTParty
-    #     pem File.read('/home/user/my.pem')
+    #     pem File.read('/home/user/my.pem'), "optional password"
     #   end
-    def pem(pem_contents)
+    def pem(pem_contents, password=nil)
       default_options[:pem] = pem_contents
+      default_options[:pem_password] = password
     end
 
     # Override the way query strings are normalized.

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -64,7 +64,7 @@ module HTTParty
         # Client certificate authentication
         if options[:pem]
           http.cert = OpenSSL::X509::Certificate.new(options[:pem])
-          http.key = OpenSSL::PKey::RSA.new(options[:pem])
+          http.key = OpenSSL::PKey::RSA.new(options[:pem], options[:pem_password])
           http.verify_mode = OpenSSL::SSL::VERIFY_PEER
         end
 

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -153,9 +153,10 @@ describe HTTParty::Request do
           @cert = mock("OpenSSL::X509::Certificate")
           @key =  mock("OpenSSL::PKey::RSA")
           OpenSSL::X509::Certificate.should_receive(:new).with(pem).and_return(@cert)
-          OpenSSL::PKey::RSA.should_receive(:new).with(pem).and_return(@key)
+          OpenSSL::PKey::RSA.should_receive(:new).with(pem, "password").and_return(@key)
 
           @request.options[:pem] = pem
+          @request.options[:pem_password] = "password"
           @pem_http = @request.send(:http)
         end
 

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -19,6 +19,25 @@ describe HTTParty do
       HTTParty::AllowedFormats.should == HTTParty::Parser::SupportedFormats
     end
   end
+  
+  describe "pem" do
+
+    it 'should set the pem content' do
+      @klass.pem 'PEM-CONTENT'
+      @klass.default_options[:pem].should == 'PEM-CONTENT'
+    end
+
+    it "should set the password to nil if it's not provided" do
+      @klass.pem 'PEM-CONTENT'
+      @klass.default_options[:pem_password].should be_nil
+    end
+
+    it 'should set the password' do
+      @klass.pem 'PEM-CONTENT', 'PASSWORD'
+      @klass.default_options[:pem_password].should == 'PASSWORD'
+    end
+
+  end
 
   describe "base uri" do
     before(:each) do


### PR DESCRIPTION
Some private keys require a password to 'unlock' them.  It's useful to be able to specify this programmatically in order to avoid being prompted.
