### PR TITLE
qualify use of Net::Foo modules in response.rb so namespace doesn't conflict

### DIFF
--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -59,7 +59,7 @@ module HTTParty
     CODES_TO_OBJ = ::Net::HTTPResponse::CODE_CLASS_TO_OBJ.merge ::Net::HTTPResponse::CODE_TO_OBJ
 
     CODES_TO_OBJ.each do |response_code, klass|
-      name = klass.name.sub("::Net::HTTP", '')
+      name = klass.name.sub("Net::HTTP", '')
       define_method("#{underscore(name)}?") do
         klass === response
       end


### PR DESCRIPTION
I'm getting "uninitialized constant HTTParty::Response::Net" errors with the existing code, but qualifying the references to Net::___ modules with a leading double-colon (like ::Net::___) in response.rb fixes the problem.
