### PR TITLE
Fix digest auth for unspecified quality of protection (qop)

### DIFF
--- a/lib/httparty/net_digest_auth.rb
+++ b/lib/httparty/net_digest_auth.rb
@@ -3,33 +3,69 @@ require 'net/http'
 
 module Net
   module HTTPHeader
-    def digest_auth(user, password, response)
-      response['www-authenticate'] =~ /^(\w+) (.*)/
+    def digest_auth(username, password, response)
+      @header['Authorization'] = DigestAuthenticator.new(username, password,
+          @method, @path, response).authorization_header
+    end
+    
+    
+    class DigestAuthenticator     
+      def initialize(username, password, method, path, response_header)
+        @username = username
+        @password = password
+        @method   = method
+        @path     = path
+        @response = parse(response_header)
+      end
+      
+      def authorization_header
+        @cnonce = md5(random)
+        header = [%Q(Digest username="#{@username}"),
+          %Q(realm="#{@response['realm']}"),
+          %Q(nonce="#{@response['nonce']}"),
+          %Q(uri="#{@path}"),
+          %Q(response="#{request_digest}")]
+        [%Q(cnonce="#{@cnonce}"),
+          %Q(opaque="#{@response['opaque']}"),
+          %Q(qop="#{@response['qop']}"),
+          %Q(nc="0")].each { |field| header << field } if qop_present?
+        header
+      end
+      
+    private
+    
+      def parse(response_header)
+        response_header['www-authenticate'] =~ /^(\w+) (.*)/
+        params = {}
+        $2.gsub(/(\w+)="(.*?)"/) { params[$1] = $2 }
+        params
+      end
+    
+      def qop_present?
+        @response.has_key?('qop') and not @response['qop'].empty?
+      end
+      
+      def random
+        "%x" % (Time.now.to_i + rand(65535))
+      end
+      
+      def request_digest
+        a = [md5(a1), @response['nonce'], md5(a2)]
+        a.insert(2, "0", @cnonce, @response['qop']) if qop_present?
+        md5(a.join(":"))
+      end
+      
+      def md5(str)
+        Digest::MD5.hexdigest(str)
+      end
+      
+      def a1
+        [@username, @response['realm'], @password].join(":")
+      end
 
-      params = {}
-      $2.gsub(/(\w+)="(.*?)"/) { params[$1] = $2 }
-      params.merge!("cnonce" => Digest::MD5.hexdigest("%x" % (Time.now.to_i + rand(65535))))
-
-      a_1 = Digest::MD5.hexdigest("#{user}:#{params['realm']}:#{password}")
-      a_2 = Digest::MD5.hexdigest("#{@method}:#{@path}")
-
-      request_digest = Digest::MD5.hexdigest(
-        [a_1, params['nonce'], "0", params['cnonce'], params['qop'], a_2].join(":")
-      )
-
-      header = [
-        %Q(Digest username="#{user}"),
-        %Q(realm="#{params['realm']}"),
-        %Q(qop="#{params['qop']}"),
-        %Q(uri="#{@path}"),
-        %Q(nonce="#{params['nonce']}"),
-        %Q(nc="0"),
-        %Q(cnonce="#{params['cnonce']}"),
-        %Q(opaque="#{params['opaque']}"),
-        %Q(response="#{request_digest}")
-      ]
-
-      @header['Authorization'] = header
+      def a2
+        [@method, @path].join(":")
+      end
     end
   end
 end

--- a/spec/httparty/net_digest_auth_spec.rb
+++ b/spec/httparty/net_digest_auth_spec.rb
@@ -1,0 +1,93 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
+
+describe Net::HTTPHeader::DigestAuthenticator do
+  def setup_digest(response)
+    digest = Net::HTTPHeader::DigestAuthenticator.new("Mufasa",
+      "Circle Of Life", "GET", "/dir/index.html", response)  
+    digest.stub(:random).and_return("deadbeef")
+    Digest::MD5.stub(:hexdigest) { |str| "md5(#{str})" }
+    digest
+  end
+  
+  def authorization_header
+    @digest.authorization_header.join(", ")
+  end
+
+
+  context "with specified quality of protection (qop)" do
+    before do
+      @digest = setup_digest({'www-authenticate' => 
+        'Digest realm="myhost@testrealm.com", nonce="NONCE", qop="auth"'})
+    end
+    
+    it "should set prefix" do
+      authorization_header.should =~ /^Digest /
+    end
+    
+    it "should set username" do
+      authorization_header.should include(%Q(username="Mufasa"))
+    end
+
+    it "should set digest-uri" do
+      authorization_header.should include(%Q(uri="/dir/index.html"))
+    end
+    
+    it "should set qop" do 
+      authorization_header.should include(%Q(qop="auth"))
+    end
+
+    it "should set cnonce" do
+      authorization_header.should include(%Q(cnonce="md5(deadbeef)"))
+    end
+    
+    it "should set nonce-count" do
+      authorization_header.should include(%Q(nc="0"))
+    end
+        
+    it "should set response" do
+      request_digest =
+        "md5(md5(Mufasa:myhost@testrealm.com:Circle Of Life)" +
+        ":NONCE:0:md5(deadbeef):auth:md5(GET:/dir/index.html))"
+      authorization_header.should include(%Q(response="#{request_digest}"))
+    end
+  end
+
+
+  context "with unspecified quality of protection (qop)" do
+    before do
+      @digest = setup_digest({'www-authenticate' => 
+        'Digest realm="myhost@testrealm.com", nonce="NONCE"'})
+    end
+    
+    it "should set prefix" do
+      authorization_header.should =~ /^Digest /
+    end
+      
+    it "should set username" do
+      authorization_header.should include(%Q(username="Mufasa"))
+    end
+
+    it "should set digest-uri" do
+      authorization_header.should include(%Q(uri="/dir/index.html"))
+    end
+    
+    it "should not set qop" do 
+      authorization_header.should_not include(%Q(qop=))
+    end
+    
+    it "should not set cnonce" do 
+      authorization_header.should_not include(%Q(cnonce=))
+    end
+        
+    it "should not set nonce-count" do 
+      authorization_header.should_not include(%Q(nc=))
+    end
+    
+    it "should set response" do
+      request_digest =
+        "md5(md5(Mufasa:myhost@testrealm.com:Circle Of Life)" +
+        ":NONCE:md5(GET:/dir/index.html))"
+      authorization_header.should include(%Q(response="#{request_digest}"))
+    end
+  end
+end


### PR DESCRIPTION
According to [RFC 2617](http://tools.ietf.org/html/rfc2617#page-11) the authorization request header dependents on the supported qop options by the server (see also overview on [Wikipedia](http://en.wikipedia.org/wiki/Digest_access_authentication)).
I've added digest authentication support for servers without specified qop (i.e. Apple's iCal Server).
All features and examples are green & clean...

Cheers,
Björn
