### PR TITLE
net http timeout can be a float 

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -152,7 +152,7 @@ module HTTParty
     #     default_timeout 10
     #   end
     def default_timeout(t)
-      raise ArgumentError, 'Timeout must be an integer' unless t && t.is_a?(Integer)
+      raise ArgumentError, 'Timeout must be an integer or float' unless t && (t.is_a?(Integer) || t.is_a?(Float))
       default_options[:timeout] = t
     end
 

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -101,7 +101,7 @@ module HTTParty
       http = Net::HTTP.new(uri.host, uri.port, options[:http_proxyaddr], options[:http_proxyport])
       http.use_ssl = ssl_implied?
 
-      if options[:timeout] && options[:timeout].is_a?(Integer)
+      if options[:timeout] && (options[:timeout].is_a?(Integer) || options[:timeout].is_a?(Float))
         http.open_timeout = options[:timeout]
         http.read_timeout = options[:timeout]
       end

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -232,6 +232,11 @@ describe HTTParty do
       @klass.default_timeout 10
       @klass.default_options[:timeout].should == 10
     end
+
+    it "should support floats" do
+      @klass.default_timeout 0.5
+      @klass.default_options[:timeout].should == 0.5
+    end
   end
 
   describe "debug_output" do


### PR DESCRIPTION
net http timeout can be a float for finer grained timeouts - I needed this for supporting less than one second timeouts as one second is too long for us.
