### PR TITLE
Make response respond_to? methods that it knows

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    httparty (0.7.2)
+    httparty (0.7.4)
       crack (= 0.1.8)
 
 GEM

--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -64,6 +64,11 @@ module HTTParty
         klass === response
       end
     end
+    
+    def respond_to?(name)
+      return true if [:request,:response,:parsed_response,:body,:headers].include?(name)
+      parsed_response.respond_to?(name) or response.respond_to?(name)
+    end
 
     protected
 

--- a/spec/httparty/response_spec.rb
+++ b/spec/httparty/response_spec.rb
@@ -54,6 +54,11 @@ describe HTTParty::Response do
     response = HTTParty::Response.new(@request_object, @response_object, {'foo' => 'bar'})
     response['foo'].should == 'bar'
   end
+  
+  it "should respond_to? methods it supports" do
+    response = HTTParty::Response.new(@request_object, @response_object, {'foo' => 'bar'})
+    response.respond_to?(:parsed_response).should be_true
+  end
 
   it "should be able to iterate if it is array" do
     response = HTTParty::Response.new(@request_object, @response_object, [{'foo' => 'bar'}, {'foo' => 'baz'}])


### PR DESCRIPTION
As discussed in #71, response returns false to respond_to?(:parsed_response) even though it responds to it. This breaks some version testing and error handling code in my mogli project. This change fixes respond_to? to delegate to parsed_response or response only if response itself doesn't handle it.
