### PR TITLE
Problem with latest RubyGems

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -5,7 +5,7 @@ require 'uri'
 require 'zlib'
 require 'crack'
 
-dir = Pathname(__FILE__).dirname.expand_path
+dir = Pathname(__FILE__).dirname.expand_path.to_s
 
 require dir + 'httparty/module_inheritable_attributes'
 require dir + 'httparty/cookie_hash'


### PR DESCRIPTION
We use this gem in our Webbynode gem and we have a ton of users complaining about this error:

```
fabiano@ubuntu:~$ webbynode
/usr/local/ruby/lib/ruby/site_ruby/1.9.1/rubygems.rb:1064:in `escape': can't convert Pathname to String (TypeError)
from /usr/local/ruby/lib/ruby/site_ruby/1.9.1/rubygems.rb:1064:in `block in loaded_path?'
from /usr/local/ruby/lib/ruby/site_ruby/1.9.1/rubygems.rb:1063:in `each'
from /usr/local/ruby/lib/ruby/site_ruby/1.9.1/rubygems.rb:1063:in `find'
from /usr/local/ruby/lib/ruby/site_ruby/1.9.1/rubygems.rb:1063:in `loaded_path?'
from /usr/local/ruby/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:35:in `require'
from /usr/local/ruby/lib/ruby/gems/1.9.1/gems/httparty-0.7.4/lib/httparty.rb:10:in `<top (required)>'
from /usr/local/ruby/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:54:in `require'
from /usr/local/ruby/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:54:in `require'
from /usr/local/ruby/lib/ruby/gems/1.9.1/gems/webbynode-1.0.4.3/lib/webbynode.rb:5:in `<top (required)>'
from /usr/local/ruby/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:54:in `require'
from /usr/local/ruby/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:54:in `require'
from /usr/local/ruby/lib/ruby/gems/1.9.1/gems/webbynode-1.0.4.3/bin/webbynode:4:in `<top (required)>'
from /usr/local/ruby/bin/webbynode:19:in `load'
from /usr/local/ruby/bin/webbynode:19:in `<main>'
```

And this seems to fix it.
