### PR TITLE
Request#handle_response no longer throws exceptions (but documentation says it does).

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -180,7 +180,6 @@ module HTTParty
       query_string_parts.size > 0 ? query_string_parts.join('&') : nil
     end
 
-    # Raises exception Net::XXX (http error code) if an http error occured
     def handle_response
       if response_redirects?
         options[:limit] -= 1


### PR DESCRIPTION
Since [8b52863](https://github.com/jnunemaker/httparty/commit/8b528632c1e8a7c21b4daedbfd09b4fff6e365a4#L2L99), `Request#handle_response` no longer throws exceptions, so [the comment saying that it does](https://github.com/jnunemaker/httparty/blob/v0.8.0/lib/httparty/request.rb#L183) should be removed.
