### PR TITLE
'null' and bodies made up out of spaces

### DIFF
--- a/lib/httparty/parser.rb
+++ b/lib/httparty/parser.rb
@@ -96,9 +96,9 @@ module HTTParty
     private_class_method :new
 
     # @return [Object] the parsed body
-    # @return [nil] when the response body is nil or an empty string
+    # @return [nil] when the response body is nil, an empty string, spaces only or "null"
     def parse
-      return nil if body.nil? || body.empty?
+      return nil if body.nil? || body.strip.empty? || body == "null"
       if supports_format?
         parse_supported_format
       else

--- a/spec/httparty/parser_spec.rb
+++ b/spec/httparty/parser_spec.rb
@@ -87,6 +87,16 @@ describe HTTParty::Parser do
       @parser.stub(:body => nil)
       @parser.parse.should be_nil
     end
+
+    it "returns nil for a 'null' body" do
+      @parser.stub(:body => "null")
+      @parser.parse.should be_nil
+    end
+
+    it "returns nil for a body with spaces only" do
+      @parser.stub(:body => "   ")
+      @parser.parse.should be_nil
+    end
   end
 
   describe "#supports_format?" do


### PR DESCRIPTION
The format. helper in Rails calls .to_json on the object in the body.
When using the head helper, it calls to_json on nil, resulting in
"null". Since its a null value, it isn't necessarilly incorrect, but its
debatable whether a HEAD only response should have a body at all.

On the other hand. MultiJSON doesn't parse "null", "  ", nil or an empty
string.

Of course we can also blame Net::HTTP for saying that null in the body
stands for a string with "null". Thats like having a barbeque,
forgetting the meat, but putting some lard on anyway.

So, lets just let HTTParty fix it. Everyone's invited :-)
