### PR TITLE
Allow for OAuth 1 auth by passing OAuth::AccessToken

### DIFF
--- a/examples/twitter_oauth.rb
+++ b/examples/twitter_oauth.rb
@@ -1,0 +1,31 @@
+dir = File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
+require File.join(dir, 'httparty')
+require 'oauth'
+require 'pp'
+config = YAML::load(File.read(File.join(ENV['HOME'], '.twitter_oauth')))
+
+class Twitter
+  include HTTParty
+  base_uri 'twitter.com'
+  
+  def initialize(ck, cs, tk, ts)
+    consumer = OAuth::Consumer.new(ck, cs, :site => 'http://twitter.com')
+    @access_token = OAuth::AccessToken.new(consumer, tk, ts)
+  end
+  
+  # which can be :friends, :user or :public
+  # options[:query] can be things like since, since_id, count, etc.
+  def timeline(which=:friends, options={})
+    options.merge!({:oauth_auth => @access_token})
+    self.class.get("/statuses/#{which}_timeline.json", options)
+  end
+end
+
+# Get client key/secret from your app's page on dev.twitter.com
+# To get access token/secret either do the normal access token request flow
+# or generate one on your app page
+
+twitter = Twitter.new(config['client_key'], config['client_secret'],
+                      config['token_key'], config['token_secret'])
+
+pp twitter.timeline

--- a/httparty.gemspec
+++ b/httparty.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'multi_json'
   s.add_dependency 'multi_xml'
+  s.add_dependency 'oauth'
 
   s.post_install_message = "When you HTTParty, you must party hard!"
 

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -157,6 +157,7 @@ module HTTParty
       @raw_request.initialize_http_header(options[:headers])
       @raw_request.basic_auth(username, password) if options[:basic_auth]
       setup_digest_auth if options[:digest_auth]
+      set_oauth_auth if options[:oauth_auth]
     end
 
     def setup_digest_auth
@@ -164,6 +165,14 @@ module HTTParty
       if res['www-authenticate'] != nil && res['www-authenticate'].length > 0
         @raw_request.digest_auth(username, password, res)
       end
+    end
+    
+    def set_oauth_auth
+      oauth_params = {:consumer => options[:oauth_auth].consumer,
+                      :token => options[:oauth_auth],
+                      :request_uri => uri}
+      oauth_helper = OAuth::Client::Helper.new(@raw_request, oauth_params)
+      @raw_request['Authorization'] = oauth_helper.header
     end
 
     def query_string(uri)

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -95,6 +95,17 @@ describe HTTParty::Request do
       raw_request = @request.instance_variable_get(:@raw_request)
       raw_request.instance_variable_get(:@header)['Authorization'].should_not be_nil
     end
+    
+    it "should use oauth when configured" do
+      consumer = OAuth::Consumer.new("key","secret")
+      access_token = OAuth::AccessToken.new(consumer)
+      
+      @request.options[:oauth_auth] = access_token
+      @request.send(:setup_raw_request)
+      
+      raw_request = @request.instance_variable_get(:@raw_request)
+      raw_request.instance_variable_get(:@header)['authorization'].should_not be_nil
+    end
   end
 
   describe "#uri" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require "httparty"
 
 require 'spec/autorun'
 require 'fakeweb'
+require 'oauth'
 
 def file_fixture(filename)
   open(File.join(File.dirname(__FILE__), 'fixtures', "#{filename.to_s}")).read


### PR DESCRIPTION
Added support for OAuth 1 signing when passing an OAuth::AccessToken as options[:oauth_auth].

But obtaining the access token is up to the developer.

Cheers
Kim
