### PR TITLE
Fix cukes in Ruby 1.9

### DIFF
--- a/features/steps/remote_service_steps.rb
+++ b/features/steps/remote_service_steps.rb
@@ -14,7 +14,7 @@ end
 
 Given /^that service takes (\d+) seconds to generate a response$/ do |time|
   @server_response_time = time.to_i
-  @handler.preprocessor = lambda { sleep time.to_i }
+  @handler.preprocessor = Proc.new { sleep time.to_i }
 end
 
 Given /^a remote deflate service$/ do


### PR DESCRIPTION
It appears that instance_eval in Ruby 1.9 doesn't play well with lambdas, but it does like procs. This was breaking the cukes, so I changed it to a proc and now the cukes are all green in 1.9
