### PR TITLE
Added example of custom User-Agent headers

### DIFF
--- a/examples/headers_and_user_agents.rb
+++ b/examples/headers_and_user_agents.rb
@@ -1,0 +1,6 @@
+# To send custom user agents to identify your application to a web service (or mask as a specific browser for testing), send "User-Agent" as a hash to headers as shown below.
+
+require 'httparty'
+
+APPLICATION_NAME = "Httparty" 
+response = HTTParty.get('http://example.com', :headers => {"User-Agent" => APPLICATION_NAME})


### PR DESCRIPTION
I found myself in a situation where I was testing a service that responded differently to some User-Agent headers than others (a common scenario for iPhone development or similar). I couldn't find easy documentation or example of how to user httparty to do this and found myself diving into the code itself to find what I needed to pass in. 

So I made a very simple example file to demonstrate for future users how to do this. Hopefully you find it useful. 
