### PR TITLE
Make initializer param optional to facilitate AR serialization

### DIFF
--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -3,7 +3,7 @@ module HTTParty
     class Headers
       include ::Net::HTTPHeader
 
-      def initialize(header)
+      def initialize(header = {})
         @header = header
       end
 


### PR DESCRIPTION
When creating a model like the one shown below, ActiveRecord wants to initialize a new object without sending a value to the initializer. Then, when one needs to set the value of the headers, an initializer that takes an argument is needed, making this argument optional seemed like the best solution.

``` ruby
require 'httparty'

class Whurl < ActiveRecord::Base
  serialize :request_headers, ::HTTParty::Response::Headers
  ...
end
```
