### PR TITLE
Changed username/password validation regexp so you can use a blank username

### DIFF
--- a/bin/httparty
+++ b/bin/httparty
@@ -49,7 +49,7 @@ OptionParser.new do |o|
   end
 
   o.on("-u", "--user [CREDS]", "Use basic authentication. Value should be user:password") do |u|
-    abort "Invalid credentials format. Must be user:password" unless u =~ /.+:.+/
+    abort "Invalid credentials format. Must be user:password" unless u =~ /.*:.+/
     user, password = u.split(':')
     opts[:basic_auth] = { :username => user, :password => password }
   end


### PR DESCRIPTION
Changed username/password validation regexp so you can use a blank username (useful when using the heroku API with an api key), fx

httparty -f xml -H "Accept: application/xml" -u :api_key https://api.heroku.com/apps/appname/ps
