### PR TITLE
Adds support for fragmented responses

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -339,8 +339,8 @@ module HTTParty
     #   # Simple get with full url and query parameters
     #   # ie: http://foo.com/resource.json?limit=10
     #   Foo.get('http://foo.com/resource.json', :query => {:limit => 10})
-    def get(path, options={})
-      perform_request Net::HTTP::Get, path, options
+    def get(path, options={}, &block)
+      perform_request Net::HTTP::Get, path, options, &block
     end
 
     # Allows making a post request to a url.
@@ -355,28 +355,28 @@ module HTTParty
     #   # Simple post with full url using :query option,
     #   # which gets set as form data on the request.
     #   Foo.post('http://foo.com/resources', :query => {:bar => 'baz'})
-    def post(path, options={})
-      perform_request Net::HTTP::Post, path, options
+    def post(path, options={}, &block)
+      perform_request Net::HTTP::Post, path, options, &block
     end
 
     # Perform a PUT request to a path
-    def put(path, options={})
-      perform_request Net::HTTP::Put, path, options
+    def put(path, options={}, &block)
+      perform_request Net::HTTP::Put, path, options, &block
     end
 
     # Perform a DELETE request to a path
-    def delete(path, options={})
-      perform_request Net::HTTP::Delete, path, options
+    def delete(path, options={}, &block)
+      perform_request Net::HTTP::Delete, path, options, &block
     end
 
     # Perform a HEAD request to a path
-    def head(path, options={})
-      perform_request Net::HTTP::Head, path, options
+    def head(path, options={}, &block)
+      perform_request Net::HTTP::Head, path, options, &block
     end
 
     # Perform an OPTIONS request to a path
-    def options(path, options={})
-      perform_request Net::HTTP::Options, path, options
+    def options(path, options={}, &block)
+      perform_request Net::HTTP::Options, path, options, &block
     end
 
     def default_options #:nodoc:
@@ -385,10 +385,10 @@ module HTTParty
 
     private
 
-      def perform_request(http_method, path, options) #:nodoc:
+      def perform_request(http_method, path, options, &block) #:nodoc:
         options = default_options.dup.merge(options)
         process_cookies(options)
-        Request.new(http_method, path, options).perform
+        Request.new(http_method, path, options).perform(&block)
       end
 
       def process_cookies(options) #:nodoc:
@@ -419,28 +419,28 @@ module HTTParty
     include HTTParty
   end
 
-  def self.get(*args)
-    Basement.get(*args)
+  def self.get(*args, &block)
+    Basement.get(*args, &block)
   end
 
-  def self.post(*args)
-    Basement.post(*args)
+  def self.post(*args, &block)
+    Basement.post(*args, &block)
   end
 
-  def self.put(*args)
-    Basement.put(*args)
+  def self.put(*args, &block)
+    Basement.put(*args, &block)
   end
 
-  def self.delete(*args)
-    Basement.delete(*args)
+  def self.delete(*args, &block)
+    Basement.delete(*args, &block)
   end
 
-  def self.head(*args)
-    Basement.head(*args)
+  def self.head(*args, &block)
+    Basement.head(*args, &block)
   end
 
-  def self.options(*args)
-    Basement.options(*args)
+  def self.options(*args, &block)
+    Basement.options(*args, &block)
   end
 end
 

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -19,7 +19,7 @@ describe HTTParty do
       HTTParty::AllowedFormats.should == HTTParty::Parser::SupportedFormats
     end
   end
-  
+
   describe "pem" do
 
     it 'should set the pem content' do
@@ -544,6 +544,15 @@ describe HTTParty do
     it "should be able to get html" do
       stub_http_response_with('google.html')
       HTTParty.get('http://www.google.com').should == file_fixture('google.html')
+    end
+
+    it "should be able to get chunked html" do
+      chunks = ["Chunk1", "Chunk2", "Chunk3", "Chunk4"]
+      stub_chunked_http_response_with(chunks)
+
+      HTTParty.get('http://www.google.com') do |fragment|
+        chunks.should include(fragment)
+      end.should == chunks.join
     end
 
     it "should be able parse response type json automatically" do

--- a/spec/support/stub_response.rb
+++ b/spec/support/stub_response.rb
@@ -13,6 +13,19 @@ module HTTParty
       HTTParty::Request.should_receive(:new).and_return(http_request)
     end
 
+    def stub_chunked_http_response_with(chunks)
+      response = Net::HTTPResponse.new("1.1", 200, nil)
+      response.stub(:chunked_data).and_return(chunks)
+      def response.read_body(&block)
+        @body || chunked_data.each(&block)
+      end
+
+      http_request = HTTParty::Request.new(Net::HTTP::Get, 'http://localhost', :format => "html")
+      http_request.stub_chain(:http, :request).and_yield(response).and_return(response)
+
+      HTTParty::Request.should_receive(:new).and_return(http_request)
+    end
+
     def stub_response(body, code = 200)
       @request.options[:base_uri] ||= 'http://localhost'
       unless defined?(@http) && @http


### PR DESCRIPTION
This allows fragmented responses to be used, if the server supports it.

One can now do something like this:

```
HTTParty.get("http://the.service/action") do |fragment|
    puts fragment
end
```

The method still returns the full body, so that the default behavior does not change.
