### PR TITLE
Automatically deflate responses with Content-Encoding: x-gzip

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -196,7 +196,7 @@ module HTTParty
     # Inspired by Ruby 1.9
     def handle_deflation
       case last_response["content-encoding"]
-      when "gzip"
+      when "gzip", "x-gzip"
         body_io = StringIO.new(last_response.body)
         last_response.body.replace Zlib::GzipReader.new(body_io).read
         last_response.delete('content-encoding')

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -495,8 +495,16 @@ describe HTTParty::Request do
         @last_response.stub!(:body).and_return('')
       end
 
-      it "should inflate the gzipped body" do
+      it "should inflate the gzipped body with content-encoding: gzip" do
         @last_response.stub!(:[]).with("content-encoding").and_return("gzip")
+        @request.stub!(:last_response).and_return(@last_response)
+        Zlib::GzipReader.should_receive(:new).and_return(StringIO.new(''))
+        @request.last_response.should_receive(:delete).with('content-encoding')
+        @request.send(:handle_deflation)
+      end
+
+      it "should inflate the gzipped body with content-encoding: x-gzip" do
+        @last_response.stub!(:[]).with("content-encoding").and_return("x-gzip")
         @request.stub!(:last_response).and_return(@last_response)
         Zlib::GzipReader.should_receive(:new).and_return(StringIO.new(''))
         @request.last_response.should_receive(:delete).with('content-encoding')


### PR DESCRIPTION
HTTParty doesn't automatically deflate responses with a Content-Encoding: x-gzip header; it only works with Content-Encoding: gzip. This fixes it to work with both.
