### PR TITLE
Updating to MultiJson's new load API

### DIFF
--- a/httparty.gemspec
+++ b/httparty.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Makes http fun! Also, makes consuming restful web services dead easy.}
   s.description = %q{Makes http fun! Also, makes consuming restful web services dead easy.}
 
-  s.add_dependency 'multi_json'
+  s.add_dependency 'multi_json', ">= 1.3.0"
   s.add_dependency 'multi_xml'
 
   s.post_install_message = "When you HTTParty, you must party hard!"

--- a/lib/httparty/parser.rb
+++ b/lib/httparty/parser.rb
@@ -113,7 +113,7 @@ module HTTParty
     end
 
     def json
-      MultiJson.decode(body)
+      MultiJson.load(body)
     end
 
     def yaml

--- a/spec/httparty/parser_spec.rb
+++ b/spec/httparty/parser_spec.rb
@@ -145,7 +145,7 @@ describe HTTParty::Parser do
     end
 
     it "parses json with MultiJson" do
-      MultiJson.should_receive(:decode).with('body')
+      MultiJson.should_receive(:load).with('body')
       subject.send(:json)
     end
 


### PR DESCRIPTION
MultiJson is deprecating the decode/encode methods in favor of load/dump as of https://github.com/intridea/multi_json/tree/e90fd6cb1b0293eb0c73c2f4eb0f7a1764370216 which was pushed out in v1.3.0.

This pull request updates the API to call MultiJson.load to get rid of the deprecated messages and updates the gemspec to depend on `>= 1.3.0` so nothing weird happens with mismatched versions.
