### PR TITLE
Do not treat uri's with a port of 4430 as SSL.

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -415,7 +415,7 @@ module HTTParty
 
   def self.normalize_base_uri(url) #:nodoc:
     normalized_url = url.dup
-    use_ssl = (normalized_url =~ /^https/) || normalized_url.include?(':443')
+    use_ssl = (normalized_url =~ /^https/) || (normalized_url =~ /:443\b/)
     ends_with_slash = normalized_url =~ /\/$/
 
     normalized_url.chop! if ends_with_slash

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -103,6 +103,11 @@ describe HTTParty do
       HTTParty.normalize_base_uri(uri)
       uri.should == 'http://api.foobar.com'
     end
+
+    it "should not treat uri's with a port of 4430 as ssl" do
+      uri = HTTParty.normalize_base_uri('http://api.foo.com:4430/v1')
+      uri.should == 'http://api.foo.com:4430/v1'
+    end
   end
 
   describe "headers" do


### PR DESCRIPTION
This one bit us today - if you passed a port of 4430 to HTTParty, it was converting it to https. We've fixed locally by skipping the normalization step (`default_options[:base_uri]` to the rescue) but wanted to go ahead and contribute this back.

Thanks!
