### PR TITLE
Remove goofy post install message.

### DIFF
--- a/httparty.gemspec
+++ b/httparty.gemspec
@@ -15,8 +15,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'multi_json', "~> 1.0"
   s.add_dependency 'multi_xml'
 
-  s.post_install_message = "When you HTTParty, you must party hard!"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
This post install message simply adds noise to our lives. Do we really need more noise?
I don't think so :)
