### PR TITLE
Fix an issue with proc options in child classes

### DIFF
--- a/lib/httparty/module_inheritable_attributes.rb
+++ b/lib/httparty/module_inheritable_attributes.rb
@@ -35,11 +35,12 @@ module HTTParty
         super
         @mattr_inheritable_attrs.each do |inheritable_attribute|
           ivar = "@#{inheritable_attribute}"
-          subclass.instance_variable_set(ivar, instance_variable_get(ivar).clone)
+          # Initially, set the instance variable value to be a clone of the parents value.
+          subclass.instance_variable_set ivar, HTTParty::ModuleInheritableAttributes.deep_clone(instance_variable_get(ivar))
           if instance_variable_get(ivar).respond_to?(:merge)
             method = <<-EOM
               def self.#{inheritable_attribute}
-                #{ivar} = superclass.#{inheritable_attribute}.merge HTTParty::ModuleInheritableAttributes.deep_clone(#{ivar})
+                #{ivar} = (superclass.#{inheritable_attribute}.merge(HTTParty::ModuleInheritableAttributes.deep_clone(#{ivar})))
               end
             EOM
             subclass.class_eval method

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -540,8 +540,17 @@ describe HTTParty do
     end
 
     it "works with lambda values" do
-      @child1.disable_rails_query_string_format
-      @child1.default_options[:query_string_normalizer].should be_a Proc
+      @child1.default_options[:imaginary_option] = lambda { "This is a new lambda "}
+      @child1.default_options[:imaginary_option].should be_a Proc
+    end
+
+    it 'should dup the proc on the child class' do
+      imaginary_option = lambda { "This is a new lambda" }
+      @parent.default_options[:imaginary_option] = imaginary_option
+      @parent.default_options[:imaginary_option].should be_equal imaginary_option
+      @child1.default_options[:imaginary_option]
+      @child1.default_options[:imaginary_option].should == imaginary_option
+      @child1.default_options[:imaginary_option].should_not be_equal imaginary_option
     end
 
     it "inherits default_cookies from the parent class" do


### PR DESCRIPTION
This fixes an issue with serialization issues when using proc options (e.g. disable the rails query string normalizer) introduced by the use of Marshal.dump
