### PR TITLE
Set nonce-count correctly when using digest authentication

### DIFF
--- a/lib/httparty/net_digest_auth.rb
+++ b/lib/httparty/net_digest_auth.rb
@@ -28,7 +28,7 @@ module Net
         [%Q(cnonce="#{@cnonce}"),
           %Q(opaque="#{@response['opaque']}"),
           %Q(qop="#{@response['qop']}"),
-          %Q(nc="0")].each { |field| header << field } if qop_present?
+          %Q(nc="00000001")].each { |field| header << field } if qop_present?
         header
       end
 
@@ -51,7 +51,7 @@ module Net
 
       def request_digest
         a = [md5(a1), @response['nonce'], md5(a2)]
-        a.insert(2, "0", @cnonce, @response['qop']) if qop_present?
+        a.insert(2, "00000001", @cnonce, @response['qop']) if qop_present?
         md5(a.join(":"))
       end
 

--- a/spec/httparty/net_digest_auth_spec.rb
+++ b/spec/httparty/net_digest_auth_spec.rb
@@ -41,11 +41,11 @@ describe Net::HTTPHeader::DigestAuthenticator do
     end
 
     it "should set nonce-count" do
-      authorization_header.should include(%Q(nc="0"))
+      authorization_header.should include(%Q(nc="00000001"))
     end
 
     it "should set response" do
-      request_digest = "md5(md5(Mufasa:myhost@testrealm.com:Circle Of Life):NONCE:0:md5(deadbeef):auth:md5(GET:/dir/index.html))"
+      request_digest = "md5(md5(Mufasa:myhost@testrealm.com:Circle Of Life):NONCE:00000001:md5(deadbeef):auth:md5(GET:/dir/index.html))"
       authorization_header.should include(%Q(response="#{request_digest}"))
     end
   end


### PR DESCRIPTION
RFC 2617 http://tools.ietf.org/html/rfc2617#page-12 specifies that the value of `nc` (nonce-count) should be a counter that starts at '00000001'. 

The currently implementation was using the value '0' which resulted in access denied status. When setting the value to '00000001' the request was processed normally.
