### PR TITLE
httparty shouldn't swallow the backtrace

### DIFF
--- a/lib/httparty/parser.rb
+++ b/lib/httparty/parser.rb
@@ -138,8 +138,8 @@ module HTTParty
 
     def parse_supported_format
       send(format)
-    rescue NoMethodError
-      raise NotImplementedError, "#{self.class.name} has not implemented a parsing method for the #{format.inspect} format."
+    rescue NoMethodError => e
+      raise NotImplementedError, "#{self.class.name} has not implemented a parsing method for the #{format.inspect} format.", e.backtrace
     end
   end
 end


### PR DESCRIPTION
httparty swallows the backtrace when a deserialize error happens.

Let's say JSON.parse fails due to incorrectly formatted json or because it's missing the correct data structure to deserialize the string the only error the user gets is:

NotImplementedError: HTTParty::Parser has not implemented a parsing method for the :json format.
lib/httparty/parser.rb:140:in `parse_supported_format'

Which would make people believe that there is something wrong with HTTParty::Parser or the used json library.
For proper debugging of debugging it really should propagate the original backtrace
