### PR TITLE
Fix a typo on the binary help command

### DIFF
--- a/bin/httparty
+++ b/bin/httparty
@@ -38,7 +38,7 @@ OptionParser.new do |o|
     end
   end
 
-  o.on("-H", "--header [NAME=VALUE]", "Additional HTTP headers in NAME=VALUE form") do |h|
+  o.on("-H", "--header [NAME:VALUE]", "Additional HTTP headers in NAME:VALUE form") do |h|
     abort "Invalid header specification, should be Name:Value" unless h =~ /.+:.+/
     name, value = h.split(':')
     opts[:headers][name.strip] = value.strip


### PR DESCRIPTION
--help said to use -H Header=value but it was actually -H Header:Value
