### PR TITLE
deep clone the hash instead of marshalling 

### DIFF
--- a/lib/httparty/module_inheritable_attributes.rb
+++ b/lib/httparty/module_inheritable_attributes.rb
@@ -4,6 +4,16 @@ module HTTParty
       base.extend(ClassMethods)
     end
 
+    # borrowed from Rails 3.2 ActiveSupport
+    def self.hash_deep_dup(h)
+      duplicate = h.dup
+      duplicate.each_pair do |k,v|
+        tv = duplicate[k]
+        duplicate[k] = tv.is_a?(Hash) && v.is_a?(Hash) ? hash_deep_dup(tv) : v
+      end
+      duplicate
+    end
+
     module ClassMethods #:nodoc:
       def mattr_inheritable(*args)
         @mattr_inheritable_attrs ||= [:mattr_inheritable_attrs]
@@ -22,7 +32,7 @@ module HTTParty
           if instance_variable_get(ivar).respond_to?(:merge)
             method = <<-EOM
               def self.#{inheritable_attribute}
-                #{ivar} = superclass.#{inheritable_attribute}.merge Marshal.load(Marshal.dump(#{ivar}))
+                #{ivar} = superclass.#{inheritable_attribute}.merge ModuleInheritableAttributes.hash_deep_dup(#{ivar})
               end
             EOM
             subclass.class_eval method


### PR DESCRIPTION
This prevents everything from blowing up when you've defined a debug_output source (which can't be marshaled).
