### PR TITLE
Fixed a bug in Example Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ class Twitter
   end
 
   def post(text)
-    options = { :query => {:status => text}, :basic_auth => @auth }
+    options = { :body => {:status => text}, :basic_auth => @auth }
     self.class.post('/statuses/update.json', options)
   end
 end


### PR DESCRIPTION
the code example has a bug. When making a POST request (using the post(...) method), the options should have a :body parameter, not the :query parameter. The :query parameter is only good for GET requests (that use the get(...) method) 
