### PR TITLE
Fix: Opaque value incorrectly sent in request when not present in response from server.

### DIFF
--- a/lib/httparty/net_digest_auth.rb
+++ b/lib/httparty/net_digest_auth.rb
@@ -25,10 +25,13 @@ module Net
           %Q(nonce="#{@response['nonce']}"),
           %Q(uri="#{@path}"),
           %Q(response="#{request_digest}")]
+
         [%Q(cnonce="#{@cnonce}"),
-          %Q(opaque="#{@response['opaque']}"),
           %Q(qop="#{@response['qop']}"),
           %Q(nc="0")].each { |field| header << field } if qop_present?
+
+        header << %Q(opaque="#{@response['opaque']}") if opaque_present?
+
         header
       end
 
@@ -39,6 +42,10 @@ module Net
         params = {}
         $2.gsub(/(\w+)="(.*?)"/) { params[$1] = $2 }
         params
+      end
+
+      def opaque_present?
+        @response.has_key?('opaque') and not @response['opaque'].empty?
       end
 
       def qop_present?

--- a/spec/httparty/net_digest_auth_spec.rb
+++ b/spec/httparty/net_digest_auth_spec.rb
@@ -13,6 +13,31 @@ describe Net::HTTPHeader::DigestAuthenticator do
     @digest.authorization_header.join(", ")
   end
 
+
+  context "with an opaque value in the response header" do
+    before do
+      @digest = setup_digest({
+        'www-authenticate' => 'Digest realm="myhost@testrealm.com", opaque="solid"'
+      })
+    end
+
+    it "should set opaque" do
+      authorization_header.should include(%Q(opaque="solid"))
+    end
+  end
+
+  context "without an opaque valid in the response header" do
+    before do
+      @digest = setup_digest({
+        'www-authenticate' => 'Digest realm="myhost@testrealm.com"'
+      })  
+    end
+
+    it "should not set opaque" do
+      authorization_header.should_not include(%Q(opaque=)) 
+    end
+  end
+
   context "with specified quality of protection (qop)" do
     before do
       @digest = setup_digest({


### PR DESCRIPTION
When attempting to use Digest auth against Apache/2.2.22 (Ubuntu) I was getting the following error:

```
[Fri Aug 10 08:49:47 2012] [error] [client 192.168.50.86] Digest: received invalid opaque - got `'
```

This happens because Apache is not responding with an opaque value in the header. When HTTParty responds it sends an empty value for opaque. This fix omits sending the opaque value when the server does not require it. 
