### PR TITLE
Add support for custom http connection factories

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -10,7 +10,7 @@ require 'httparty/module_inheritable_attributes'
 require 'httparty/cookie_hash'
 require 'httparty/net_digest_auth'
 require 'httparty/version'
-require 'httparty/connection_factory'
+require 'httparty/connection_adapter'
 
 # @see HTTParty::ClassMethods
 module HTTParty
@@ -58,10 +58,11 @@ module HTTParty
   # * :+maintain_method_across_redirects+: see HTTParty::ClassMethods.maintain_method_across_redirects.
   # * :+no_follow+: see HTTParty::ClassMethods.no_follow.
   # * :+parser+: see HTTParty::ClassMethods.parser.
-  # * :+connection_factory+: see HTTParty::ClassMethods.connection_factory.
+  # * :+connection_adapter+: see HTTParty::ClassMethods.connection_adapter.
   # * :+pem+: see HTTParty::ClassMethods.pem.
   # * :+query_string_normalizer+: see HTTParty::ClassMethods.query_string_normalizer
   # * :+ssl_ca_file+: see HTTParty::ClassMethods.ssl_ca_file.
+  # * :+ssl_ca_path+: see HTTParty::ClassMethods.ssl_ca_path.
 
   module ClassMethods
 
@@ -333,19 +334,27 @@ module HTTParty
       end
     end
 
-    # Allows setting a custom connection_factory for the http connections
+    # Allows setting a custom connection_adapter for the http connections
     #
+    # @example
     #   class Foo
     #     include HTTParty
-    #     connection_factory Proc.new {|uri, options| ... }
+    #     connection_adapter Proc.new {|uri, options| ... }
     #   end
     #
-    # @see HTTParty::ConnectionFactory
-    def connection_factory(custom_factory = nil)
-      if custom_factory.nil?
-        default_options[:connection_factory]
+    # @example provide optional configuration for your connection_adapter
+    #   class Foo
+    #     include HTTParty
+    #     connection_adapter Proc.new {|uri, options| ... }, {:foo => :bar}
+    #   end
+    #
+    # @see HTTParty::ConnectionAdapter
+    def connection_adapter(custom_adapter = nil, options = nil)
+      if custom_adapter.nil?
+        default_options[:connection_adapter]
       else
-        default_options[:connection_factory] = custom_factory
+        default_options[:connection_adapter] = custom_adapter
+        default_options[:connection_adapter_options] = options
       end
     end
 

--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -1,24 +1,26 @@
 module HTTParty
-  # Default connection factory that returns a new Net::HTTP each time
+  # Default connection adapter that returns a new Net::HTTP each time
   #
   # == Custom Connection Factories
   #
-  # If you like to implement your own connection factory, subclassing
-  # HTTPParty::ConnectionFactory will make it easier. Just override
+  # If you like to implement your own connection adapter, subclassing
+  # HTTPParty::ConnectionAdapter will make it easier. Just override
   # the #connection method. The uri and options attributes will have
   # all the info you need to construct your http connection. Whatever
   # you return from your connection method needs to adhere to the
   # Net::HTTP interface as this is what HTTParty expects.
   #
-  # @example Ignore all options
-  #   class NoConfigConnectionFactory < HTTParty::ConnectionFactory
+  # @example log the uri and options
+  #   class LoggingConnectionAdapter < HTTParty::ConnectionAdapter
   #     def connection
+  #       puts uri
+  #       puts options
   #       Net::HTTP.new(uri)
   #     end
   #   end
   #
   # @example count number of http calls
-  #   class CountingConnectionFactory < HTTParty::ConnectionFactory
+  #   class CountingConnectionAdapter < HTTParty::ConnectionAdapter
   #     @@count = 0
   #
   #     self.count
@@ -30,7 +32,20 @@ module HTTParty
   #       super
   #     end
   #   end
-  class ConnectionFactory
+  #
+  # === Configuration
+  # There is lots of configuration data available for your connection adapter
+  # in the #options attribute. It is up to you to interpret them within your
+  # connection adapter. Take a look at the implementation of
+  # HTTParty::ConnectionAdapter#connection for examples of how they are used.
+  # Something are probably interesting are as follows:
+  # * :+timeout+: timeout in seconds
+  # * :+debug_output+: see HTTParty::ClassMethods.debug_output.
+  # * :+pem+: contains pem data. see HTTParty::ClassMethods.pem.
+  # * :+ssl_ca_file+: see HTTParty::ClassMethods.ssl_ca_file.
+  # * :+ssl_ca_path+: see HTTParty::ClassMethods.ssl_ca_path.
+  # * :+connection_adapter_options+: contains the hash your passed to HTTParty.connection_adapter when you configured your connection adapter
+  class ConnectionAdapter
 
     def self.call(uri, options)
       new(uri, options).connection

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -34,7 +34,7 @@ module HTTParty
         :default_params => {},
         :follow_redirects => true,
         :parser => Parser,
-        :connection_factory => ConnectionFactory
+        :connection_adapter => ConnectionAdapter
       }.merge(o)
     end
 
@@ -69,8 +69,8 @@ module HTTParty
       options[:parser]
     end
 
-    def connection_factory
-      options[:connection_factory]
+    def connection_adapter
+      options[:connection_adapter]
     end
 
     def perform(&block)
@@ -98,7 +98,7 @@ module HTTParty
     private
 
     def http
-      connection_factory.call(uri, options)
+      connection_adapter.call(uri, options)
     end
 
     def body

--- a/spec/httparty/connection_adapter_spec.rb
+++ b/spec/httparty/connection_adapter_spec.rb
@@ -1,59 +1,59 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
 
-describe HTTParty::ConnectionFactory do
+describe HTTParty::ConnectionAdapter do
 
   describe "initialization" do
     let(:uri) { URI 'http://www.google.com' }
     it "takes a URI as input" do
-      HTTParty::ConnectionFactory.new(uri)
+      HTTParty::ConnectionAdapter.new(uri)
     end
 
     it "raises an ArgumentError if the uri is nil" do
-      expect { HTTParty::ConnectionFactory.new(nil) }.to raise_error ArgumentError
+      expect { HTTParty::ConnectionAdapter.new(nil) }.to raise_error ArgumentError
     end
 
     it "raises an ArgumentError if the uri is a String" do
-      expect { HTTParty::ConnectionFactory.new('http://www.google.com') }.to raise_error ArgumentError
+      expect { HTTParty::ConnectionAdapter.new('http://www.google.com') }.to raise_error ArgumentError
     end
 
     it "sets the uri" do
-      factory = HTTParty::ConnectionFactory.new(uri)
-      factory.uri.should be uri
+      adapter = HTTParty::ConnectionAdapter.new(uri)
+      adapter.uri.should be uri
     end
 
     it "also accepts an optional options hash" do
-      HTTParty::ConnectionFactory.new(uri, {})
+      HTTParty::ConnectionAdapter.new(uri, {})
     end
 
     it "sets the options" do
       options = {:foo => :bar}
-      factory = HTTParty::ConnectionFactory.new(uri, options)
-      factory.options.should be options
+      adapter = HTTParty::ConnectionAdapter.new(uri, options)
+      adapter.options.should be options
     end
   end
 
   describe ".call" do
-    it "generates an HTTParty::ConnectionFactory instance with the given uri and options" do
-      HTTParty::ConnectionFactory.should_receive(:new).with(@uri, @options).and_return(stub(:connection => nil))
-      HTTParty::ConnectionFactory.call(@uri, @options)
+    it "generates an HTTParty::ConnectionAdapter instance with the given uri and options" do
+      HTTParty::ConnectionAdapter.should_receive(:new).with(@uri, @options).and_return(stub(:connection => nil))
+      HTTParty::ConnectionAdapter.call(@uri, @options)
     end
 
-    it "calls #connection on the connection factory" do
-      factory = mock('Factory')
+    it "calls #connection on the connection adapter" do
+      adapter = mock('Adapter')
       connection = mock('Connection')
-      factory.should_receive(:connection).and_return(connection)
-      HTTParty::ConnectionFactory.stub(:new => factory)
-      HTTParty::ConnectionFactory.call(@uri, @options).should be connection
+      adapter.should_receive(:connection).and_return(connection)
+      HTTParty::ConnectionAdapter.stub(:new => adapter)
+      HTTParty::ConnectionAdapter.call(@uri, @options).should be connection
     end
   end
 
   describe '#connection' do
     let(:uri) { URI 'http://www.google.com' }
     let(:options) { Hash.new }
-    let(:factory) { HTTParty::ConnectionFactory.new(uri, options) }
+    let(:adapter) { HTTParty::ConnectionAdapter.new(uri, options) }
 
     describe "the resulting connection" do
-      subject { factory.connection }
+      subject { adapter.connection }
       it { should be_an_instance_of Net::HTTP }
 
       context "when dealing with ssl" do
@@ -91,7 +91,7 @@ describe HTTParty::ConnectionFactory do
           http.should_not_receive(:read_timeout=)
           Net::HTTP.stub(:new => http)
 
-          factory.connection
+          adapter.connection
         end
       end
 
@@ -112,7 +112,7 @@ describe HTTParty::ConnectionFactory do
             http.should_not_receive(:read_timeout=)
             Net::HTTP.stub(:new => http)
 
-            factory.connection
+            adapter.connection
           end
         end
       end
@@ -127,14 +127,14 @@ describe HTTParty::ConnectionFactory do
           let(:options) { {:debug_output => $stderr} }
           it "has debug output set" do
             http.should_receive(:set_debug_output).with($stderr)
-            factory.connection
+            adapter.connection
           end
         end
 
         context "is not provided" do
           it "does not set_debug_output" do
             http.should_not_receive(:set_debug_output)
-            factory.connection
+            adapter.connection
           end
         end
       end

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -46,15 +46,15 @@ describe HTTParty::Request do
       request.parser.should == my_parser
     end
 
-    it "sets connection_factory to HTTPParty::ConnectionFactory" do
+    it "sets connection_adapter to HTTPParty::ConnectionAdapter" do
       request = HTTParty::Request.new(Net::HTTP::Get, 'http://google.com')
-      request.connection_factory.should == HTTParty::ConnectionFactory
+      request.connection_adapter.should == HTTParty::ConnectionAdapter
     end
 
-    it "sets connection_factory to the optional connection_factory" do
-      my_factory = lambda {}
-      request = HTTParty::Request.new(Net::HTTP::Get, 'http://google.com', :connection_factory => my_factory)
-      request.connection_factory.should == my_factory
+    it "sets connection_adapter to the optional connection_adapter" do
+      my_adapter = lambda {}
+      request = HTTParty::Request.new(Net::HTTP::Get, 'http://google.com', :connection_adapter => my_adapter)
+      request.connection_adapter.should == my_adapter
     end
   end
 
@@ -156,11 +156,11 @@ describe HTTParty::Request do
   end
 
   describe 'http' do
-    it "should get a connection from the connection_factory" do
+    it "should get a connection from the connection_adapter" do
       http = Net::HTTP.new('google.com')
-      factory = mock('factory')
-      request = HTTParty::Request.new(Net::HTTP::Get, 'https://api.foo.com/v1:443', :connection_factory => factory)
-      factory.should_receive(:call).with(request.uri, request.options).and_return(http)
+      adapter = mock('adapter')
+      request = HTTParty::Request.new(Net::HTTP::Get, 'https://api.foo.com/v1:443', :connection_adapter => adapter)
+      adapter.should_receive(:call).with(request.uri, request.options).and_return(http)
       request.send(:http).should be http
     end
   end


### PR DESCRIPTION
I followed the same pattern used for the parser. This opens the door to being able to do things like use a pool of persistent HTTP connections. Let me know what you think and if there are any changes you would like to see.
