### PR TITLE
Allow the SSL version to be specified for a request

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -131,6 +131,10 @@ module HTTParty
         http.set_debug_output(options[:debug_output])
       end
 
+      if options[:ssl_version] && http.use_ssl?
+        http.ssl_version = options[:ssl_version]
+      end
+
       http
     end
 

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -106,6 +106,16 @@ describe HTTParty::Request do
       @post_request.options[:digest_auth] = {:username => 'foobar', :password => 'secret'}
       @post_request.send(:setup_raw_request)
     end
+
+    it 'should use the right ssl version when configured' do
+      request = HTTParty::Request.new(Net::HTTP::Get, 'https://api.foo.com/v1', :format => :xml)
+      FakeWeb.register_uri(:get, "https://api.foo.com/v1", {})
+
+      request.options[:ssl_version] = 'SSLv3'
+      request.send(:setup_raw_request)
+
+      request.send(:http).ssl_version.should == 'SSLv3'
+    end
   end
 
   describe "#uri" do


### PR DESCRIPTION
The `Net/HTTP` library allows you to specify the SSL version that SSL connections use. This patch allows that version to be specified for an `HTTParty` request. 

Example:

``` ruby
HTTParty.get('https://some.url.com', :ssl_version => 'SSLv3')
```

Specs added, and spec suite is green.
