### PR TITLE
digest auth won't work without content-length

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -140,6 +140,7 @@ module HTTParty
     def setup_digest_auth
       auth_request = http_method.new(uri.request_uri)
       auth_request.initialize_http_header(options[:headers])
+      auth_request.body = ''
       res = http.request(auth_request)
 
       if res['www-authenticate'] != nil && res['www-authenticate'].length > 0


### PR DESCRIPTION
OK guys help me out. I'm trying to use http digest auth and I'm running into a bad time.

You guys are much more knowledgeable about this than me so if I'm missing something please let me know. This is my current understanding of how digest works.
1. You send a request to the server. I would like to place this information here.
2. Server  says, no way. If you want in here's some special nonce super secret stuff you have to mess with.
3. The client looks at the super secret stuff and makes some special sauce with some authentication header and re-submits it - this time the server looks at it and says yes looks good to me.

The issue I'm having is when the initial request is a POST request. It is not sending the content-length when we send a POST. As we all know sending a POST request without the content-length ends up with a nasty 411, so you don't get your nonce stuff (at least with webrick).

Attempting to to post using digest auth using Curl works fine, but fails using httparty.

I'm assuming that most requests are GET in nature and this hasn't been seen. I did some searching and found this -- https://github.com/jnunemaker/httparty/issues/57 looks like it's fixed but I'm definitely getting the 411 and POSTS using digest auth are failing.

So I just manually set body to empty string which seems to set the content length properly and everything works.

So  main questions are:
1. how do you guys want to test this? Please give me a pointer. It looks like this has been an issue before but wasn't really tested properly. Should I test the format of the http request itself?
2. Does including a body affect simple GET requests adversely?
3. I would think that POST's and PUT's would automatically make sure they had content-length headers. If so, does the actual problem reside elsewhere?

Comments greatly appreciated.
