### PR TITLE
Redirecting to locations containing a parent or current directory reference

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -162,9 +162,9 @@ module HTTParty
     end
 
     def handle_response(body)
-      if response_redirects?
-        options[:limit] -= 1
-        self.path = last_response['location']
+      if response_redirects?                      
+        options[:limit] -= 1        
+        self.path = URI.parse(last_response['location']).relative? ? @last_uri.merge(last_response['location']).to_s : last_response['location']
         self.redirect = true
         self.http_method = Net::HTTP::Get unless options[:maintain_method_across_redirects]
         capture_cookies(last_response)

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -269,24 +269,50 @@ describe HTTParty::Request do
           @http.stub!(:request).and_return(redirect, ok)
           response = @request.perform
           response.request.base_uri.to_s.should == "http://api.foo.com"
-          response.request.path.to_s.should == "/foo/bar"
+          response.request.path.to_s.should == "http://api.foo.com/foo/bar"
           response.request.uri.request_uri.should == "/foo/bar"
           response.request.uri.to_s.should == "http://api.foo.com/foo/bar"
           response.should == {"hash" => {"foo" => "bar"}}
-        end
+        end   
+
+        it "redirects if a 300 contains a relative location header with a current directory path" do
+          redirect = stub_response '', 300
+          redirect['location'] = './foo/bar'
+          ok = stub_response('<hash><foo>bar</foo></hash>', 200)
+          @http.stub!(:request).and_return(redirect, ok)
+          response = @request.perform
+          response.request.base_uri.to_s.should == "http://api.foo.com"
+          response.request.path.to_s.should == "http://api.foo.com/foo/bar"
+          response.request.uri.request_uri.should == "/foo/bar"
+          response.request.uri.to_s.should == "http://api.foo.com/foo/bar"
+          response.should == {"hash" => {"foo" => "bar"}}
+        end        
+
+        it "redirects if a 300 contains a relative location header with a parent directory path" do
+          redirect = stub_response '', 300
+          redirect['location'] = '../moose'
+          ok = stub_response('<hash><moose>bullwinkle</moose></hash>', 200)
+          @http.stub!(:request).and_return(redirect, ok)
+          response = @request.perform
+          response.request.base_uri.to_s.should == "http://api.foo.com"
+          response.request.path.to_s.should == "http://api.foo.com/moose"
+          response.request.uri.request_uri.should == "/moose"
+          response.request.uri.to_s.should == "http://api.foo.com/moose"
+          response.should == {"hash" => {"moose" => "bullwinkle"}}
+        end        
 
         it "handles multiple redirects and relative location headers on different hosts" do
           @request = HTTParty::Request.new(Net::HTTP::Get, 'http://test.com/redirect', :format => :xml)
-          FakeWeb.register_uri(:get, "http://test.com/redirect", :status => [300, "REDIRECT"], :location => "http://api.foo.com/v2")
-          FakeWeb.register_uri(:get, "http://api.foo.com/v2", :status => [300, "REDIRECT"], :location => "/v3")
+          FakeWeb.register_uri(:get, "http://test.com/redirect", :status => [300, "REDIRECT"], :location => "http://api.foo.com/v2/bar")
+          FakeWeb.register_uri(:get, "http://api.foo.com/v2/bar", :status => [300, "REDIRECT"], :location => "../v3")
           FakeWeb.register_uri(:get, "http://api.foo.com/v3", :body => "<hash><foo>bar</foo></hash>")
           response = @request.perform
           response.request.base_uri.to_s.should == "http://api.foo.com"
-          response.request.path.to_s.should == "/v3"
+          response.request.path.to_s.should == "http://api.foo.com/v3"
           response.request.uri.request_uri.should == "/v3"
           response.request.uri.to_s.should == "http://api.foo.com/v3"
           response.should == {"hash" => {"foo" => "bar"}}
-        end
+        end        
 
         it "returns the HTTParty::Response when the 300 does not contain a location header" do
           net_response = stub_response '', 300


### PR DESCRIPTION
I was having some problems with redirects on a site that redirected to locations using parent and current directory references.  This pull request contains a small change to handle those types of locations.

Neil.
