### PR TITLE
Redirect successfully when location is relative and omits a leading slash

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -164,7 +164,7 @@ module HTTParty
     def handle_response(body)
       if response_redirects?
         options[:limit] -= 1
-        self.path = last_response['location']
+        self.path = URI.parse(last_response['location']).relative? ? URI.join(last_uri, last_response['location']).path : last_response['location']
         self.redirect = true
         self.http_method = Net::HTTP::Get unless options[:maintain_method_across_redirects]
         capture_cookies(last_response)


### PR DESCRIPTION
NB: It's not clear if this violates the (proposed) RFC, but browsers
handle it, and it has been encountered in the wild.
