### PR TITLE
Allow SSL Cipher to be specified on the HTTP Request

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -310,6 +310,19 @@ module HTTParty
       default_options[:ssl_version] = version
     end
 
+    # Allows setting of SSL ciphers to use.
+    # You can get a list of valid specific ciphers from OpenSSL::Cipher.ciphers.
+    # You also can specify a cipher suite here, listed here at openssl.org: 
+    # http://www.openssl.org/docs/apps/ciphers.html#CIPHER_SUITE_NAMES
+    #
+    #   class Foo
+    #     include HTTParty
+    #     ciphers "RC4-SHA"
+    #   end
+    def ciphers(cipher_names)
+      default_options[:ciphers] = cipher_names
+    end
+
     # Allows setting an OpenSSL certificate authority file
     #
     #   class Foo

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -98,7 +98,9 @@ module HTTParty
     private
 
     def http
-      connection_adapter.call(uri, options)
+      adapter = connection_adapter.call(uri, options)
+      adapter.ciphers = options[:ciphers] if options[:ciphers]
+      adapter
     end
 
     def body

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -119,6 +119,14 @@ describe HTTParty::Request do
     end
   end
 
+  it "should configure the http connection adapter with ciphers if supplied" do
+    @post_request = HTTParty::Request.new(Net::HTTP::Post, 'http://api.foo.com/v1', :ciphers => 'RC4-SHA')
+    FakeWeb.register_uri(:post, "http://api.foo.com/v1", {})
+
+    http = @post_request.send(:http)
+    http.ciphers.should == 'RC4-SHA'
+  end
+
   describe "#uri" do
     context "query strings" do
       it "does not add an empty query string when default_params are blank" do

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -45,6 +45,14 @@ describe HTTParty do
     end
   end
 
+  describe 'ciphers' do
+    it 'should set the ciphers content' do
+      @klass.default_options[:ciphers].should be_nil
+      @klass.ciphers 'RC4-SHA'
+      @klass.default_options[:ciphers].should == 'RC4-SHA'
+    end
+  end
+
   describe 'http_proxy' do
     it 'should set the address' do
       @klass.http_proxy 'proxy.foo.com', 80


### PR DESCRIPTION
Add support for passing in ciphers information into the ConnectionAdapter, and have this work as expected with the Net:HTTP ConnectionAdapter.
