### PR TITLE
fix a warning because path= is redefined below

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -24,7 +24,8 @@ module HTTParty
       end.flatten.sort.join('&')
     end
 
-    attr_accessor :http_method, :path, :options, :last_response, :redirect, :last_uri
+    attr_accessor :http_method, :options, :last_response, :redirect, :last_uri
+    attr_reader :path
 
     def initialize(http_method, path, o={})
       self.http_method = http_method


### PR DESCRIPTION
Without this patch, I run the following foo.rb:

  require 'rubygems'
  require 'httparty'
  puts "hello"

and get this output:

  $ ruby -w foo.rb /var/lib/gems/1.8/gems/httparty-0.7.7/lib/httparty/request.rb:39:
  warning: method redefined; discarding old path=
  hello

Since we plan to define path= below, just use attr_reader instead of
attr_accessor in the first place, and the warning goes away.

I'm using this version of ruby:

  $ ruby -v
  ruby 1.8.7 (2010-08-16 patchlevel 302) [i486-linux]
