### PR TITLE
Allow SSL Cipher to be specified on the HTTP Request Edit

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -299,7 +299,7 @@ module HTTParty
       default_options[:query_string_normalizer] = normalizer
     end
 
-    # Allows setting of SSL version to use. This only works in Ruby 1.9.
+    # Allows setting of SSL version to use. This only works in Ruby 1.9+.
     # You can get a list of valid versions from OpenSSL::SSL::SSLContext::METHODS.
     #
     #   class Foo
@@ -308,6 +308,19 @@ module HTTParty
     #   end
     def ssl_version(version)
       default_options[:ssl_version] = version
+    end
+
+    # Allows setting of SSL ciphers to use.  This only works in Ruby 1.9+.
+    # You can get a list of valid specific ciphers from OpenSSL::Cipher.ciphers.
+    # You also can specify a cipher suite here, listed here at openssl.org: 
+    # http://www.openssl.org/docs/apps/ciphers.html#CIPHER_SUITE_NAMES
+    #
+    #   class Foo
+    #     include HTTParty
+    #     ciphers "RC4-SHA"
+    #   end
+    def ciphers(cipher_names)
+      default_options[:ciphers] = cipher_names
     end
 
     # Allows setting an OpenSSL certificate authority file

--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -76,6 +76,10 @@ module HTTParty
         http.set_debug_output(options[:debug_output])
       end
 
+      if options[:ciphers]
+        http.ciphers = options[:ciphers]
+      end
+
       return http
     end
 

--- a/spec/httparty/connection_adapter_spec.rb
+++ b/spec/httparty/connection_adapter_spec.rb
@@ -78,6 +78,7 @@ describe HTTParty::ConnectionAdapter do
           it { should use_ssl }
         end
 
+
         context "when ssl version is set" do
           let(:options) { {:ssl_version => :TLSv1} }
 
@@ -86,6 +87,14 @@ describe HTTParty::ConnectionAdapter do
           end
         end if RUBY_VERSION > '1.9'
       end
+
+      context "specifying ciphers" do
+        let(:options) { {:ciphers => 'RC4-SHA' } }
+
+        it "should set the ciphers on the connection" do
+          subject.ciphers.should == 'RC4-SHA'
+        end
+      end if RUBY_VERSION > '1.9'
 
       context "when timeout is not set" do
         it "doesn't set the timeout" do

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -45,6 +45,14 @@ describe HTTParty do
     end
   end
 
+  describe 'ciphers' do
+    it 'should set the ciphers content' do
+      @klass.default_options[:ciphers].should be_nil
+      @klass.ciphers 'RC4-SHA'
+      @klass.default_options[:ciphers].should == 'RC4-SHA'
+    end
+  end
+
   describe 'http_proxy' do
     it 'should set the address' do
       @klass.http_proxy 'proxy.foo.com', 80


### PR DESCRIPTION
Add support for passing in ciphers information into the ConnectionAdapter, and have this work as expected with the Net:HTTP ConnectionAdapter.

This is a modified version of #175.

I also only run the test in Ruby 1.9+, and document that this only works in this version of Ruby.
