### PR TITLE
Bump multi_xml dependency to 0.5.2 for CVE-2013-0175 fix

### DIFF
--- a/httparty.gemspec
+++ b/httparty.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{Makes http fun! Also, makes consuming restful web services dead easy.}
 
   s.add_dependency 'multi_json', "~> 1.0"
-  s.add_dependency 'multi_xml'
+  s.add_dependency 'multi_xml', ">= 0.5.2"
 
   s.post_install_message = "When you HTTParty, you must party hard!"
 


### PR DESCRIPTION
See sferik/multi_xml#34 for details.
