### PR TITLE
MOVE Http request handling

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -429,6 +429,11 @@ module HTTParty
       perform_request Net::HTTP::Delete, path, options, &block
     end
 
+    # Perform a MOVE request to a path
+    def move(path, options={}, &block)
+      perform_request Net::HTTP::Move, path, options, &block
+    end
+
     # Perform a HEAD request to a path
     def head(path, options={}, &block)
       perform_request Net::HTTP::Head, path, options, &block
@@ -499,6 +504,10 @@ module HTTParty
     Basement.delete(*args, &block)
   end
 
+  def self.move(*args, &block)
+    Basement.move(*args, &block)
+  end
+  
   def self.head(*args, &block)
     Basement.head(*args, &block)
   end

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -7,7 +7,8 @@ module HTTParty
       Net::HTTP::Put,
       Net::HTTP::Delete,
       Net::HTTP::Head,
-      Net::HTTP::Options
+      Net::HTTP::Options,
+      Net::HTTP::Move
     ]
 
     SupportedURISchemes  = [URI::HTTP, URI::HTTPS, URI::Generic]

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -358,6 +358,11 @@ describe HTTParty::Request do
         @request.perform.should == {"hash" => {"foo" => "bar"}}
       end
 
+      it "should be handled by MOVE transparently" do
+        @request.http_method = Net::HTTP::Move
+        @request.perform.should == {"hash" => {"foo" => "bar"}}
+      end
+
       it "should be handled by PATCH transparently" do
         @request.http_method = Net::HTTP::Patch
         @request.perform.should == {"hash" => {"foo" => "bar"}}

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -491,6 +491,12 @@ describe HTTParty do
       end.should raise_error(HTTParty::RedirectionTooDeep) {|e| e.response.body.should == 'first redirect'}
     end
 
+    it "should fail with redirected MOVE" do
+      lambda do
+        @klass.move('/foo', :no_follow => true)
+      end.should raise_error(HTTParty::RedirectionTooDeep) {|e| e.response.body.should == 'first redirect'}
+    end
+
     it "should fail with redirected PUT" do
       lambda do
         @klass.put('/foo', :no_follow => true)


### PR DESCRIPTION
I've added MOVE http request handling feature. Microsoft Skydrive API uses MOVE request mode to transfer files from one folder to another. So this would be a nice addition to HTTParty so that developers can create wrappers for Skydrive API. (I am currently working on one)
