### PR TITLE
Incorrect value being tested for being a Hash

### DIFF
--- a/lib/httparty/hash_conversions.rb
+++ b/lib/httparty/hash_conversions.rb
@@ -37,7 +37,7 @@ module HTTParty
 
       stack.each do |parent, hash|
         hash.each do |k, v|
-          if value.is_a?(Hash)
+          if v.is_a?(Hash)
             stack << ["#{parent}[#{k}]", v]
           else
             param << normalize_param("#{parent}[#{k}]", v)


### PR DESCRIPTION
I think a rename was missed when fixing the warnings. The example with nested hashes at the top of the file was not working for me with version 10.0.1.

The following  would fail with: undefined method `each' for "111 Ruby Ave."

options = 
       { :name => "Bob",
         :address => {
           :street => '111 Ruby Ave.',
           :city => 'Ruby Central',
           :phones => ['111-111-1111', '222-222-2222']
         }
       }

HTTParty::HashConversions.to_params(options)
