### PR TITLE
Some servers return cookies with 'Path' attribute instead of 'path'

### DIFF
--- a/lib/httparty/cookie_hash.rb
+++ b/lib/httparty/cookie_hash.rb
@@ -17,6 +17,6 @@ class HTTParty::CookieHash < Hash #:nodoc:
   end
 
   def to_cookie_string
-    delete_if { |k, v| CLIENT_COOKIES.include?(k.to_s) }.collect { |k, v| "#{k}=#{v}" }.join("; ")
+    delete_if { |k, v| CLIENT_COOKIES.include?(k.to_s.downcase) }.collect { |k, v| "#{k}=#{v}" }.join("; ")
   end
 end

--- a/spec/httparty/cookie_hash_spec.rb
+++ b/spec/httparty/cookie_hash_spec.rb
@@ -66,5 +66,11 @@ describe HTTParty::CookieHash do
       @s = @cookie_hash.to_cookie_string
       @s.should_not match(/path=\//)
     end
+
+    it "should not include client side only cookies even when attributes use camal case" do
+      @cookie_hash.add_cookies(:Path => "/")
+      @s = @cookie_hash.to_cookie_string
+      @s.should_not match(/Path=\//)
+    end
   end
 end


### PR DESCRIPTION
I was having an issue with 302's which set cookies. Specifically from a service which returned the `Set-Cookie` header containing a `Path` attribute. 

`CookieHash` already strips these attributes, but only the lowercase versions.

This fixes this issue. 
