### PR TITLE
Don't duplicate query string arguments.

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -53,7 +53,7 @@ module HTTParty
     end
 
     def uri
-      new_uri = path.relative? ? URI.parse("#{base_uri}#{path}") : path
+      new_uri = path.relative? ? URI.parse("#{base_uri}#{path}") : path.clone
 
       # avoid double query string on redirects [#12]
       unless redirect

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -133,6 +133,12 @@ describe HTTParty::Request do
         URI.unescape(@request.uri.query).should == ""
       end
 
+      it "does not duplicate query string parameters when uri is called twice" do
+        @request.options[:query] = {:foo => :bar}
+        @request.uri
+        @request.uri.query.should == "foo=bar"
+      end
+
       context "when representing an array" do
         it "returns a Rails style query string" do
           @request.options[:query] = {:foo => %w(bar baz)}


### PR DESCRIPTION
This is related to #185.

During the course of an actual request, the Request#uri method is called more
than once. If the request's path is not relative, that method destructively
updates `@path`, and so parameters get duplicated each time uri is called. This
change clones the path first (and adds a lame test).
