### PR TITLE
add support for charset param

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -179,11 +179,11 @@ module HTTParty
         return nil
       end
 
-      if content_type =~ /;\s*charset\s*=\s*([^=,;"\s]+)/
+      if content_type =~ /;\s*charset\s*=\s*([^=,;"\s]+)/i
         return $1
       end
 
-      if content_type =~ /;\s*charset\s*=\s*"((\\.|[^\\"])+)"/
+      if content_type =~ /;\s*charset\s*=\s*"((\\.|[^\\"])+)"/i
         return $1.gsub(/\\(.)/, '\1')
       end
 

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -248,6 +248,13 @@ describe HTTParty::Request do
         resp.body.encoding.should == Encoding.find("UTF-8")
       end
 
+      it "should process charset in content type properly if it has a different case" do
+        response = stub_response "Content"
+        response.initialize_http_header("Content-Type" => "text/plain;CHARSET = utf-8")
+        resp = @request.perform
+        resp.body.encoding.should == Encoding.find("UTF-8")
+      end
+
       it "should process quoted charset in content type properly" do
         response = stub_response "Content"
         response.initialize_http_header("Content-Type" => "text/plain;charset = \"utf-8\"")


### PR DESCRIPTION
if the response includes the charset param in the
content type header the body will have the
correct encoding set.

if the response has utf-16 set as the content
type it will try and do BOM detection. otherwise
it will default to big endian. this can be 
overridden with the assume_utf16_is_big_endian
option.

this makes the json parsing usable with utf-16 
since utf-16 will not parse correctly if it has
been incorrectly marked as ascii.
