### PR TITLE
Adding java check in aliasing of multiple choices.

### DIFF
--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -41,7 +41,7 @@ module HTTParty
     end
 
     # Support old multiple_choice? method from pre 2.0.0 era.
-    if ::RUBY_VERSION >= "2.0.0"
+    if ::RUBY_VERSION >= "2.0.0" && ::RUBY_PLATFORM != "java"
       alias_method :multiple_choice?, :multiple_choices?
     end
 

--- a/spec/httparty/response_spec.rb
+++ b/spec/httparty/response_spec.rb
@@ -198,7 +198,7 @@ describe HTTParty::Response do
       }
 
       # Ruby 2.0, new name for this response.
-      if RUBY_VERSION >= "2.0.0"
+      if RUBY_VERSION >= "2.0.0" && ::RUBY_PLATFORM != "java"
         SPECIFIC_CODES[:multiple_choices?] = Net::HTTPMultipleChoices
       end
 


### PR DESCRIPTION
This is needed to hack around a lack of compatibility between
ruby 2.0 and jruby compat.version=2.0.
