### PR TITLE
Added option to allow bad requests to raise an error.

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -61,6 +61,7 @@ module HTTParty
   # * :+connection_adapter+: see HTTParty::ClassMethods.connection_adapter.
   # * :+pem+: see HTTParty::ClassMethods.pem.
   # * :+query_string_normalizer+: see HTTParty::ClassMethods.query_string_normalizer
+  # * :+raise_error_on_bad_request+: see HTTParty::ClassMethods.raise_error_on_bad_request
   # * :+ssl_ca_file+: see HTTParty::ClassMethods.ssl_ca_file.
   # * :+ssl_ca_path+: see HTTParty::ClassMethods.ssl_ca_path.
 
@@ -297,6 +298,13 @@ module HTTParty
     # @yieldreturn [Array] an array that will later be joined with '&'
     def query_string_normalizer(normalizer)
       default_options[:query_string_normalizer] = normalizer
+    end
+
+    # Raise an HTTParty::ResponseError on 400- and 500-level response status codes.
+    # 4xx status codes will raise HTTParty::ClientError.
+    # 5xx status codes will raise HTTParty::ServerError.
+    def raise_error_on_bad_request(value = false)
+      default_options[:raise_error_on_bad_request] = value
     end
 
     # Allows setting of SSL version to use. This only works in Ruby 1.9+.

--- a/lib/httparty/exceptions.rb
+++ b/lib/httparty/exceptions.rb
@@ -23,4 +23,14 @@ module HTTParty
   # Exception that is raised when request has redirected too many times.
   # Calling {#response} returns the Net:HTTP response object.
   class RedirectionTooDeep < ResponseError; end
+
+  # Exception that is raised when response has a 400-level status code.
+  # Only used if HTTParty raise_error_on_bad_request option is set.
+  # Calling {#response} returns the Net:HTTP response object.
+  class ClientError < ResponseError; end
+
+  # Exception that is raised when response has a 400-level status code.
+  # Only used if HTTParty raise_error_on_bad_request option is set.
+  # Calling {#response} returns the Net:HTTP response object.
+  class ServerError < ResponseError; end
 end

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -38,7 +38,8 @@ module HTTParty
         :default_params => {},
         :follow_redirects => true,
         :parser => Parser,
-        :connection_adapter => ConnectionAdapter
+        :connection_adapter => ConnectionAdapter,
+        :raise_error_on_bad_request => false
       }.merge(o)
     end
 
@@ -253,6 +254,10 @@ module HTTParty
       else
         body = body || last_response.body
         body = encode_body(body)
+        if options[:raise_error_on_bad_request]
+          raise ServerError.new(last_response) if last_response.code.to_i >= 500
+          raise ClientError.new(last_response) if last_response.code.to_i >= 400
+        end
         Response.new(self, last_response, lambda { parse_response(body) }, :body => body)
       end
     end

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -459,6 +459,18 @@ describe HTTParty do
     end
   end
 
+  describe "#raise_error_on_bad_request" do
+    it "sets the raise_error_on_bad_request option to false by default" do
+      @klass.raise_error_on_bad_request
+      @klass.default_options[:raise_error_on_bad_request].should be_false
+    end
+
+    it "sets the raise_error_on_bad_request option to true" do
+      @klass.raise_error_on_bad_request true
+      @klass.default_options[:raise_error_on_bad_request].should be_true
+    end
+  end
+
   describe "with explicit override of automatic redirect handling" do
     before do
       @request = HTTParty::Request.new(Net::HTTP::Get, 'http://api.foo.com/v1', :format => :xml, :no_follow => true)


### PR DESCRIPTION
400- and 500-level requests will raise HTTParty::ClientError and
HTTParty::ServerError respectively, when the raise_error_on_bad_request option
is set.

Included specs.
