### PR TITLE
Add cookie parsing support

### DIFF
--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -26,6 +26,20 @@ module HTTParty
       response.code.to_i
     end
 
+    def cookies
+      cookie_list = []
+      headers['set-cookie'].split(', ').each do |cookie|
+        cookie_hash = {}
+        cookie.split('; ').each do |cookie_part|
+          array = cookie_part.split('=',2)
+          cookie_hash[array[0].to_sym] = array[1]
+        end
+        cookie_list << cookie_hash
+      end
+
+      cookie_list
+    end
+
     def inspect
       inspect_id = "%x" % (object_id * 2)
       %(#<#{self.class}:0x#{inspect_id} parsed_response=#{parsed_response.inspect}, @response=#{response.inspect}, @headers=#{headers.inspect}>)
@@ -46,7 +60,7 @@ module HTTParty
     end
 
     def respond_to?(name)
-      return true if [:request, :response, :parsed_response, :body, :headers].include?(name)
+      return true if [:request, :response, :parsed_response, :body, :headers, :cookies].include?(name)
       parsed_response.respond_to?(name) || response.respond_to?(name)
     end
 

--- a/spec/httparty/response_spec.rb
+++ b/spec/httparty/response_spec.rb
@@ -75,6 +75,11 @@ describe HTTParty::Response do
     response.respond_to?(:headers).should be_true
   end
 
+  it "responds to cookies" do
+    response = HTTParty::Response.new(@request_object, @response_object, @parsed_response)
+    response.respond_to?(:cookies).should be_true
+  end
+
   it "responds to parsed_response" do
     response = HTTParty::Response.new(@request_object, @response_object, @parsed_response)
     response.respond_to?(:parsed_response).should be_true
@@ -103,6 +108,13 @@ describe HTTParty::Response do
     @response_object.add_field 'set-cookie', '_github_ses=A123CdE; path=/'
     response = HTTParty::Response.new(@request_object, @response_object, @parsed_response)
     response.headers['set-cookie'].should == "csrf_id=12345; path=/, _github_ses=A123CdE; path=/"
+  end
+
+  it "returns cookies as a list of hash values" do
+    @response_object.add_field 'set-cookie', 'csrf_id=12345; path=/'
+    @response_object.add_field 'set-cookie', '_github_ses=A123CdE; path=/'
+    response = HTTParty::Response.new(@request_object, @response_object, @parsed_response)
+    response.cookies.should == [{:csrf_id => '12345', :path => '/'},{:_github_ses => 'A123CdE', :path => '/'}]
   end
 
   # Backwards-compatibility - previously, #headers returned a Hash


### PR DESCRIPTION
Right now, the only way to get cookie values out of the response is to manually parse them out of `response.headers['set-cookie']`. This PR adds `#cookies` to the `Response` class to prevent each client from having to parse them.

Tests are included. Ruby is not my main language, so please let me know if something needs to be changed for style reasons.
