### PR TITLE
Do not pass proxy options to Net::HTTP connection if not specified

### DIFF
--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -66,7 +66,11 @@ module HTTParty
 
     def connection
       host = clean_host(uri.host)
-      http = Net::HTTP.new(host, uri.port, options[:http_proxyaddr], options[:http_proxyport], options[:http_proxyuser], options[:http_proxypass])
+      if options[:http_proxyaddr]
+        http = Net::HTTP.new(host, uri.port, options[:http_proxyaddr], options[:http_proxyport], options[:http_proxyuser], options[:http_proxypass])
+      else
+        http = Net::HTTP.new(host, uri.port)
+      end
 
       http.use_ssl = ssl_implied?(uri)
 

--- a/spec/httparty/connection_adapter_spec.rb
+++ b/spec/httparty/connection_adapter_spec.rb
@@ -176,6 +176,16 @@ describe HTTParty::ConnectionAdapter do
         end
       end
 
+      context 'when not providing a proxy address' do
+        let(:uri) { URI 'http://proxytest.com' }
+
+        it "does not pass any proxy parameters to the connection" do
+          http = Net::HTTP.new("proxytest.com")
+          Net::HTTP.should_receive(:new).once.with("proxytest.com", 80).and_return(http)
+          adapter.connection
+        end
+      end
+
       context "when providing PEM certificates" do
         let(:pem) { :pem_contents }
         let(:options) { {:pem => pem, :pem_password => "password"} }

--- a/spec/httparty/ssl_spec.rb
+++ b/spec/httparty/ssl_spec.rb
@@ -27,10 +27,10 @@ describe HTTParty::Request do
     end
 
     it "should work when using ssl_ca_path with a certificate authority" do
-      http = Net::HTTP.new('www.google.com', 443, nil, nil, nil, nil)
+      http = Net::HTTP.new('www.google.com', 443)
       response = stub(Net::HTTPResponse, :[] => '', :body => '', :to_hash => {})
       http.stub(:request).and_return(response)
-      Net::HTTP.should_receive(:new).with('www.google.com', 443, nil, nil, nil, nil).and_return(http)
+      Net::HTTP.should_receive(:new).with('www.google.com', 443).and_return(http)
       http.should_receive(:ca_path=).with('/foo/bar')
       HTTParty.get('https://www.google.com', :ssl_ca_path => '/foo/bar')
     end


### PR DESCRIPTION
Ruby 2.0 has changed the Net::HTTP.new method so that if you don't specify
a proxy address it defaults to using the proxy specified by the http_proxy
environment variable (if set). Passing nil for the proxy address now means
that a proxy is never used even if the http_proxy environment variable is
set.

However HTTParty was always passing the proxy option values even if they
were nil, which meant that the defaulting to http_proxy environment variable
didn't work.

With this change the proxy values are only passed if http_proxyaddr is non-nil.

See issue #184 for further details.
