### PR TITLE
Cookies are comma separated according to rfc2109 4.2.2

### DIFF
--- a/lib/httparty/cookie_hash.rb
+++ b/lib/httparty/cookie_hash.rb
@@ -7,7 +7,8 @@ class HTTParty::CookieHash < Hash #:nodoc:
     when Hash
       merge!(value)
     when String
-      value.split('; ').each do |cookie|
+      value.split(',').each do |cookies|
+        cookie, av  = cookies.strip.split(';', 2)
         array = cookie.split('=',2)
         self[array[0].to_sym] = array[1]
       end

--- a/spec/httparty/cookie_hash_spec.rb
+++ b/spec/httparty/cookie_hash_spec.rb
@@ -23,7 +23,7 @@ describe HTTParty::CookieHash do
 
     describe "with a string" do
       it "should add new key/value pairs to the hash" do
-        @cookie_hash.add_cookies("first=one; second=two; third")
+        @cookie_hash.add_cookies("first=one, second=two, third")
         @cookie_hash[:first].should == 'one'
         @cookie_hash[:second].should == 'two'
         @cookie_hash[:third].should == nil
@@ -37,10 +37,15 @@ describe HTTParty::CookieHash do
       end
 
       it "should handle '=' within cookie value" do
-          @cookie_hash.add_cookies("first=one=1; second=two=2==")
+          @cookie_hash.add_cookies("first=one=1, second=two=2==")
           @cookie_hash.keys.should include(:first, :second)
           @cookie_hash[:first].should == 'one=1'
           @cookie_hash[:second].should == 'two=2=='
+      end
+
+      it "should handle cookie attribute value pairs" do
+        @cookie_hash.add_cookies("CFID=18370245;path=/, CFTOKEN=1973a7761f5a9072%2DEDC14302%2DDA2D%2D8382%2D10F4C5B06060CF60;path=/, TEST_COOKIES=TRUE;expires=Tue, 28-Jul-2043 20:16:54 GMT;path=/")
+        @cookie_hash.keys.should include(:CFID, :CFTOKEN, :TEST_COOKIES)
       end
     end
 

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -475,7 +475,7 @@ describe HTTParty::Request do
       end
 
       it "should keep track of cookies between redirects" do
-        @redirect['Set-Cookie'] = 'foo=bar; name=value; HTTPOnly'
+        @redirect['Set-Cookie'] = 'foo=bar, name=value; HTTPOnly'
         @request.perform
         @request.options[:headers]['Cookie'].should match(/foo=bar/)
         @request.options[:headers]['Cookie'].should match(/name=value/)
@@ -496,8 +496,8 @@ describe HTTParty::Request do
       end
 
       it "should handle multiple Set-Cookie headers between redirects" do
-        @redirect.add_field 'set-cookie', 'foo=bar; name=value; HTTPOnly'
-        @redirect.add_field 'set-cookie', 'one=1; two=2; HTTPOnly'
+        @redirect.add_field 'set-cookie', 'foo=bar, name=value; HTTPOnly'
+        @redirect.add_field 'set-cookie', 'one=1, two=2; HTTPOnly'
         @request.perform
         @request.options[:headers]['Cookie'].should match(/foo=bar/)
         @request.options[:headers]['Cookie'].should match(/name=value/)


### PR DESCRIPTION
The syntax for the Set-Cookie response header is

```
set-cookie      =       "Set-Cookie:" cookies
cookies         =       1#cookie
cookie          =       NAME "=" VALUE *(";" cookie-av)
NAME            =       attr
VALUE           =       value
cookie-av       =       "Comment" "=" value
               |       "Domain" "=" value
               |       "Max-Age" "=" value
               |       "Path" "=" value
               |       "Secure"
               |       "Version" "=" 1*DIGIT
```

For example (2 cookies, with attribute value pairs):
USER=john;domain=.example.com;path=/, PREFS=123123;path=/

This commit is not a full cookie store implementation as the path
should be compared against the request path to determine if the
cookie should be transmitted to the server, along with expired
cookies should be removed.
