### PR TITLE
Fix example URLs

### DIFF
--- a/examples/crack.rb
+++ b/examples/crack.rb
@@ -15,5 +15,5 @@ class Rep
   )
 end
 
-pp Rep.get('http://whoismyrepresentative.com/whoismyrep.php?zip=46544')
-pp Rep.get('http://whoismyrepresentative.com/whoismyrep.php', :query => {:zip => 46544})
+pp Rep.get('http://whoismyrepresentative.com/getall_mems.php?zip=46544')
+pp Rep.get('http://whoismyrepresentative.com/getall_mems.php', :query => {:zip => 46544})

--- a/examples/whoismyrep.rb
+++ b/examples/whoismyrep.rb
@@ -6,5 +6,5 @@ class Rep
   include HTTParty
 end
 
-pp Rep.get('http://whoismyrepresentative.com/whoismyrep.php?zip=46544')
-pp Rep.get('http://whoismyrepresentative.com/whoismyrep.php', :query => {:zip => 46544})
+pp Rep.get('http://whoismyrepresentative.com/getall_mems.php?zip=46544')
+pp Rep.get('http://whoismyrepresentative.com/getall_mems.php', :query => {:zip => 46544})


### PR DESCRIPTION
I noticed the API changed for the "whoismyrepresentative" examples, so here's a fix.
