### PR TITLE
Remove post-install message

### DIFF
--- a/httparty.gemspec
+++ b/httparty.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'json',      "~> 1.8"
   s.add_dependency 'multi_xml', ">= 0.5.2"
 
-  s.post_install_message = "When you HTTParty, you must party hard!"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
Hey John,

I've been using `httparty` in a project for the past few months. It's great! Thank you.

I was hoping you would consider removing the post-install message, though. Often, gems emit important information  in this hook, and it can be missed if gems are using the post-install message for fun. I have personally almost missed important information after finishing installs due to `httparty`.

I saw that someone else [submitted a PR a year ago](https://github.com/jnunemaker/httparty/pull/139) for the same reason, which was closed.

I was hoping that, given the passage of time, you may reconsider. In the previous PR, you linked to a number of tweets that were positive about the message. The first time I saw it, I was confused. The second time, I laughed and thought it was funny. After several months, though, I just find it to be an unfunny distraction.

Yesterday, I tweeted out of frustration (https://twitter.com/tomdale/status/382243102007631873) about the message. The tweet (where I used harsher language than I should have; sorry) seemed to resonate with people. I got many replies, favorites and retweets.

Given that the novelty has worn off, the message doesn't provide any functional value, and many people find it distracting, annoying, or harmful, please consider this a humble request to reconsider the previous pull request. I agree with your assessment that whimsy in programming is very important, but not when it teaches people to ignore potentially important information.

Best,
Tom
