### PR TITLE
Don't try to parse javascript as JSON

### DIFF
--- a/features/handles_multiple_formats.feature
+++ b/features/handles_multiple_formats.feature
@@ -32,3 +32,11 @@ Feature: Handles Multiple Formats
     Then it should return a Hash equaling:
        | key    | value           |
        | singer | waylon jennings |
+
+  Scenario: A Javascript remote file
+    Given a remote service that returns '$(function() { alert("hi"); });'
+    And that service is accessed at the path '/service.js'
+    And the response from the service has a Content-Type of 'application/javascript'
+    When I call HTTParty#get with '/service.js'
+    Then it should return a String
+    And the return value should match '$(function() { alert("hi"); });'

--- a/lib/httparty/parser.rb
+++ b/lib/httparty/parser.rb
@@ -42,8 +42,8 @@ module HTTParty
       'application/xml'        => :xml,
       'application/json'       => :json,
       'text/json'              => :json,
-      'application/javascript' => :json,
-      'text/javascript'        => :json,
+      'application/javascript' => :plain,
+      'text/javascript'        => :plain,
       'text/html'              => :html,
       'text/plain'             => :plain
     }

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -198,13 +198,13 @@ describe HTTParty::Request do
 
     it 'should handle text/javascript' do
       ["text/javascript", "text/javascript; charset=iso8859-1"].each do |ct|
-        @request.send(:format_from_mimetype, ct).should == :json
+        @request.send(:format_from_mimetype, ct).should == :plain
       end
     end
 
     it 'should handle application/javascript' do
       ["application/javascript", "application/javascript; charset=iso8859-1"].each do |ct|
-        @request.send(:format_from_mimetype, ct).should == :json
+        @request.send(:format_from_mimetype, ct).should == :plain
       end
     end
 


### PR DESCRIPTION
Trying to download files with the mime-type application/javascript (pure
javascript files) ends up running through the JSON parser. As javascript
code is not JSON, so this ends up throwing a MultiJSON::LoadError.
