### PR TITLE
Coerce path parameter to allow URI objects to be passed as arguments

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -31,7 +31,7 @@ module HTTParty
 
     def initialize(http_method, path, o={})
       self.http_method = http_method
-      self.path = path
+      self.path = URI(path).to_s
       self.options = {
         :limit => o.delete(:no_follow) ? 1 : 5,
         :assume_utf16_is_big_endian => true,

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
 
 describe HTTParty::Request do
   before do
-    @request = HTTParty::Request.new(Net::HTTP::Get, 'http://api.foo.com/v1', :format => :xml)
+    @request = HTTParty::Request.new(Net::HTTP::Get, URI('http://api.foo.com/v1'), :format => :xml)
   end
 
   describe "::NON_RAILS_QUERY_STRING_NORMALIZER" do


### PR DESCRIPTION
HTTParty.get(URI('http://google.com')) will throws the error URI::InvalidURIError: bad URI(is not URI?): http://google.com
Coercing the path to a URI and then to a string allows URIs to be passed as arguments and ensures nil will still throw 
Idea originated whilst reading Avdi Grimms' 'Confident Ruby'
