### PR TITLE
Sorting query parameters undesireable

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -15,7 +15,7 @@ module HTTParty
     SupportedURISchemes  = [URI::HTTP, URI::HTTPS, URI::Generic]
 
     NON_RAILS_QUERY_STRING_NORMALIZER = Proc.new do |query|
-      Array(query).map do |key, value|
+      Array(query).sort_by { |a| a[0].to_s }.map do |key, value|
         if value.nil?
           key.to_s
         elsif value.is_a?(Array)

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -17,12 +17,12 @@ describe HTTParty::Request do
 
       it "doesn't include brackets" do
         query_string = normalizer[{:page => 1, :foo => %w(bar baz)}]
-        URI.unescape(query_string).should == "page=1&foo=bar&foo=baz"
+        URI.unescape(query_string).should == "foo=bar&foo=baz&page=1"
       end
 
       it "URI encodes array values" do
-        query_string = normalizer[{:people => ["Bob Marley", "Tim & Jon"]}]
-        query_string.should == "people=Bob%20Marley&people=Tim%20%26%20Jon"
+        query_string = normalizer[{:people => ["Otis Redding", "Bob Marley", "Tim & Jon"], :page => 1, :xyzzy => 3}]
+        query_string.should == "page=1&people=Otis%20Redding&people=Bob%20Marley&people=Tim%20%26%20Jon&xyzzy=3"
       end
     end
 
@@ -156,7 +156,7 @@ describe HTTParty::Request do
         @request.options[:body] = {:page => 1, :foo => %w(bar baz)}
         @request.send(:setup_raw_request)
         body = @request.instance_variable_get(:@raw_request).body
-        URI.unescape(body).should == "page=1&foo=bar&foo=baz"
+        URI.unescape(body).should == "foo=bar&foo=baz&page=1"
       end
     end
   end


### PR DESCRIPTION
Some services return results based on the query parameter order (ex: mapquest's batch query api), and sorting may break input/output mapping unexpectedly.

~~Patch removes the sort call from the NON_RAILS_QUERY_STRING_NORMALIZER proc, and updates spec expectations accordingly.~~

[Edit]
Patch sorts query parameters by key in the NON_RAILS_QUERY_STRING_NORMALIZER proc, prior to processing. This adds some consistency across ruby versions during the actual processing, and removes the value sorting which affected query array values

Updates the array value test to check for maintained query values, and sorting of keys. 
