### PR TITLE
Remove redundant `dup`

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -492,7 +492,7 @@ module HTTParty
     private
 
       def perform_request(http_method, path, options, &block) #:nodoc:
-        options = default_options.dup.merge(options)
+        options = default_options.merge(options)
         process_cookies(options)
         Request.new(http_method, path, options).perform(&block)
       end


### PR DESCRIPTION
Hash#merge returns a new Hash:
http://ruby-doc.org/core-2.0.0/Hash.html#method-i-merge
