### PR TITLE
Allow to provide basic auth credentials in URL

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -40,6 +40,7 @@ module HTTParty
         parser: Parser,
         connection_adapter: ConnectionAdapter
       }.merge(o)
+      set_basic_auth_from_uri
     end
 
     def path=(uri)
@@ -334,6 +335,13 @@ module HTTParty
 
     def post?
       Net::HTTP::Post == http_method
+    end
+
+    def set_basic_auth_from_uri
+      if path.userinfo
+        username, password = path.userinfo.split(':')
+        options[:basic_auth] = {:username => username, :password => password}
+      end
     end
   end
 end

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -56,6 +56,23 @@ describe HTTParty::Request do
       request = HTTParty::Request.new(Net::HTTP::Get, 'http://google.com', connection_adapter: my_adapter)
       request.connection_adapter.should == my_adapter
     end
+
+    context "when basic authentication credentials provided in uri" do
+      context "when basic auth options wasn't set explicitly" do
+        it "sets basic auth from uri" do
+          request = HTTParty::Request.new(Net::HTTP::Get, 'http://user1:pass1@example.com')
+          request.options[:basic_auth].should == {:username => 'user1', :password => 'pass1'}
+        end
+      end
+
+      context "when basic auth options was set explicitly" do
+        it "uses basic auth from url anyway" do
+          basic_auth = {:username => 'user2', :password => 'pass2'}
+          request = HTTParty::Request.new(Net::HTTP::Get, 'http://user1:pass1@example.com', :basic_auth => basic_auth)
+          request.options[:basic_auth].should == {:username => 'user1', :password => 'pass1'}
+        end
+      end
+    end
   end
 
   describe "#format" do


### PR DESCRIPTION
Add ability to provide basic auth credentials in URL in form `http://user:password@example.com`.
Explicitly specified `basic_auth` option have precedence over this one in URL.
