### PR TITLE
Fixed superfluous ampersand when queries are embedded in paths

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -174,6 +174,7 @@ module HTTParty
         query_string_parts << options[:query] unless options[:query].nil?
       end
 
+      query_string_parts.reject!(&:empty?) unless query_string_parts == [""]
       query_string_parts.size > 0 ? query_string_parts.join('&') : nil
     end
 

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -133,6 +133,12 @@ describe HTTParty::Request do
         URI.unescape(@request.uri.query).should == ""
       end
 
+      it "does not append an ampersand when queries are embedded in paths" do
+        @request.path = "/path?a=1"
+        @request.options[:query] = {}
+        @request.uri.query.should == "a=1"
+      end
+
       it "does not duplicate query string parameters when uri is called twice" do
         @request.options[:query] = {:foo => :bar}
         @request.uri


### PR DESCRIPTION
I'm using httparty to communicate with a REST service running deployd, which has a somewhat odd (yet legal) <a href="http://docs.deployd.com/docs/collections/reference/querying-collections.md">query syntax</a>. These queries fail in httparty because it is adding a superfluous ampersand to the end of them. This commit fixes that problem. I have also included a test that exercises the problem.
