### PR TITLE
don't change http to https when using port 443

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -512,13 +512,17 @@ module HTTParty
 
   def self.normalize_base_uri(url) #:nodoc:
     normalized_url = url.dup
-    use_ssl = (normalized_url =~ /^https/) || (normalized_url =~ /:443\b/)
+    use_ssl = self.use_ssl?(normalized_url)
     ends_with_slash = normalized_url =~ /\/$/
 
     normalized_url.chop! if ends_with_slash
     normalized_url.gsub!(/^https?:\/\//i, '')
 
     "http#{'s' if use_ssl}://#{normalized_url}"
+  end
+
+  def self.use_ssl?(url)
+    (url =~ /^https/) || (!(url =~ /^http:/) && url =~ /:443\b/)
   end
 
   class Basement #:nodoc:

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -120,6 +120,11 @@ describe HTTParty do
       uri.should == 'https://api.foo.com/v1:443'
     end
 
+    it "should not add https for non ssl requests" do
+      uri = HTTParty.normalize_base_uri('http://api.foo.com/v1:443')
+      uri.should == 'http://api.foo.com/v1:443'
+    end
+
     it "should not remove https for ssl requests" do
       uri = HTTParty.normalize_base_uri('https://api.foo.com/v1:443')
       uri.should == 'https://api.foo.com/v1:443'


### PR DESCRIPTION
Even though port 443 by default uses SSL, we should be able to override the default by specifying plain HTTP (non-SSL) in the scheme. `http://foo.com:443` should not be changed to `https://foo.com:443` just because it's port 443.
