### PR TITLE
Modernize respond_to implementations

### DIFF
--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -50,9 +50,9 @@ module HTTParty
       alias_method :multiple_choice?, :multiple_choices?
     end
 
-    def respond_to?(name)
+    def respond_to?(name, include_all = false)
       return true if [:request, :response, :parsed_response, :body, :headers].include?(name)
-      parsed_response.respond_to?(name) || response.respond_to?(name)
+      parsed_response.respond_to?(name, include_all) || response.respond_to?(name, include_all)
     end
 
     protected

--- a/lib/httparty/response/headers.rb
+++ b/lib/httparty/response/headers.rb
@@ -23,8 +23,8 @@ module HTTParty
         end
       end
 
-      def respond_to?(method)
-        super || @header.respond_to?(method)
+      def respond_to?(method, include_all = false)
+        super || @header.respond_to?(method, include_all)
       end
     end
   end


### PR DESCRIPTION
Since at least Ruby 1.8.7, `respond_to?` has supported an optional
second parameter which causes private/protected methods to be included
in the check. This defaults to false.

As of Ruby 2, there's a warning logged if an implementation of
`respond_to` does not take a second parameter, see:
https://github.com/ruby/ruby/commit/a106b310e5bbe678022b127b9d32bb0a55708002

This change updated the respond_to implementations to support the second
parameter and squelch this warning.
