### PR TITLE
Initialize HTTParty requests with an URI object and a String.

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -43,7 +43,7 @@ module HTTParty
     end
 
     def path=(uri)
-      @path = URI.parse(uri)
+      @path = URI(uri)
     end
 
     def request_uri(uri)


### PR DESCRIPTION
Change `URI.parse(uri)` to `URI(uri)` so that HTTParty consuming code can make requests with:

``` ruby
uri = URI('http://www.google.com/')
HTTParty.get(uri)
```

as opposed to 

``` ruby
uri = URI('http://www.google.com/')
HTTParty.get(uri.to_s)
```

without throwing and invalid URI exception.
