### PR TITLE
Add cookies from Set-Cookie header in digest auth setup response

### DIFF
--- a/spec/httparty/net_digest_auth_spec.rb
+++ b/spec/httparty/net_digest_auth_spec.rb
@@ -13,6 +13,34 @@ describe Net::HTTPHeader::DigestAuthenticator do
     @digest.authorization_header.join(", ")
   end
 
+  def cookie_header
+    @digest.cookie_header
+  end
+
+  context "with a cookie value in the response header" do
+    before do
+      @digest = setup_digest({
+        'www-authenticate' => 'Digest realm="myhost@testrealm.com"',
+        'Set-Cookie' => 'custom-cookie=1234567'
+      })
+    end
+
+    it "should set cookie header" do
+      cookie_header.should include('custom-cookie=1234567')
+    end
+  end
+
+  context "without a cookie value in the response header" do
+    before do
+      @digest = setup_digest({
+        'www-authenticate' => 'Digest realm="myhost@testrealm.com"'
+      })
+    end
+
+    it "should set empty cookie header array" do
+      cookie_header.should eql []
+    end
+  end
 
   context "with an opaque value in the response header" do
     before do


### PR DESCRIPTION
There are no tests because being in the module I could not find a good hook to test this with.  Open to suggestions on best way to test this.

We have been using this monkey patch internally and is working well.
