### PR TITLE
Remove awful post_install_message.

### DIFF
--- a/httparty.gemspec
+++ b/httparty.gemspec
@@ -18,9 +18,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'json',      "~> 1.8"
   s.add_dependency 'multi_xml', ">= 0.5.2"
 
-  # If this line is removed, all hard partying will cease.
-  s.post_install_message = "When you HTTParty, you must party hard!"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
It's awful. And it doesn't just effect people who choose to use this library. It blights the output of `bundle` even when it's a second or Nth-level dependency.

Others including @raykrueger @h3h @nbibler @olivierlacan @lparry @tobico @eric @tomdale @locks @shime @nt1 @avdi @christhekeele @markijbema @marten @harto agree:
- https://github.com/jnunemaker/httparty/pull/139
- https://github.com/jnunemaker/httparty/pull/211
- https://github.com/jnunemaker/httparty/pull/236
- https://github.com/jnunemaker/httparty/pull/237
- https://github.com/jnunemaker/httparty/pull/294
- https://github.com/jnunemaker/httparty/pull/315

I'll keep trying to solve this downstream by encouraging other libraries to not use httparty, but it'd be great to fix it centrally.
