### PR TITLE
Fix client certificate authentication

### DIFF
--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -153,9 +153,9 @@ module HTTParty
         end
 
         # Client certificate authentication
-        if options[:pem]
+        if options[:pem] && options[:pem_key]
           http.cert = OpenSSL::X509::Certificate.new(options[:pem])
-          http.key = OpenSSL::PKey::RSA.new(options[:pem], options[:pem_password])
+          http.key = OpenSSL::PKey::RSA.new(options[:pem_key], options[:pem_password])
           http.verify_mode = options[:verify_peer] == false ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
         end
 


### PR DESCRIPTION
It must be possible to provide two different files: a pem file and a key file.
