### PR TITLE
set correct path on redirect to filename

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -56,6 +56,10 @@ module HTTParty
     end
 
     def uri
+      if redirect && path.relative? && path.path[0] != "/"
+        path.path = @last_uri.path.gsub(/[^\/]+$/, "") + path.path
+      end
+
       new_uri = path.relative? ? URI.parse("#{base_uri}#{path}") : path.clone
 
       # avoid double query string on redirects [#12]

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -144,6 +144,32 @@ describe HTTParty::Request do
   end
 
   describe "#uri" do
+    context "redirects" do
+      it "returns correct path when the server sets the location header to a filename" do
+        @request.last_uri = URI.parse("http://example.com/foo/bar")
+        @request.path = URI.parse("bar?foo=bar")
+        @request.redirect = true
+
+        @request.uri.should == URI.parse("http://example.com/foo/bar?foo=bar")
+      end
+
+      it "returns correct path when the server sets the location header to a relative path" do
+        @request.last_uri = URI.parse("http://example.com/foo/bar")
+        @request.path = URI.parse("/bar?foo=bar")
+        @request.redirect = true
+
+        @request.uri.should == URI.parse("http://example.com/bar?foo=bar")
+      end
+
+      it "returns correct path when the server sets the location header to an absolute path" do
+        @request.last_uri = URI.parse("http://example.com/foo/bar")
+        @request.path = URI.parse("http://example.com/bar?foo=bar")
+        @request.redirect = true
+
+        @request.uri.should == URI.parse("http://example.com/bar?foo=bar")
+      end
+    end
+
     context "query strings" do
       it "does not add an empty query string when default_params are blank" do
         @request.options[:default_params] = {}


### PR DESCRIPTION
I apologize if this is heinous - I'm completely new to how HTTP works, and this is a guess at how to fix a problem I've had a couple times.

When I make a GET request to a certain website, I get a 302 response with the location header set to the same filename (but without the full path) with a different query string. When attempting to follow that redirect, httparty makes a GET request to a broken url and I get an `getaddrinfo: nodename nor servname provided, or not known (SocketError)` exception.

For example:
- GET `http://example.com/foo/bar`
- Server responds 302 with location header set to `bar?token=123`
- On https://github.com/jnunemaker/httparty/blob/master/lib/httparty/request.rb#L59, `#uri` sets `new_uri` to `http://example.combar?token=123`
- Sadness :(
