### PR TITLE
quotes qop value prior to parsing

### DIFF
--- a/lib/httparty/net_digest_auth.rb
+++ b/lib/httparty/net_digest_auth.rb
@@ -44,7 +44,10 @@ module Net
     private
 
       def parse(response_header)
-        response_header['www-authenticate'] =~ /Digest (.*)/
+        header = response_header['www-authenticate']
+          .gsub(/qop=(auth(?:-int)?)/, %Q(qop="\\1"))
+
+        header =~ /Digest (.*)/
         params = {}
         $1.gsub(/(\w+)="(.*?)"/) { params[$1] = $2 }
         params

--- a/spec/httparty/net_digest_auth_spec.rb
+++ b/spec/httparty/net_digest_auth_spec.rb
@@ -75,6 +75,17 @@ describe Net::HTTPHeader::DigestAuthenticator do
     end
   end
 
+  context "when quality of protection (qop) is unquoted" do
+    before do
+      @digest = setup_digest({
+        'www-authenticate' => 'Digest realm="myhost@testrealm.com", nonce="NONCE", qop=auth',
+      })
+    end
+
+    it "should still set qop" do
+      authorization_header.should include(%Q(qop="auth"))
+    end
+  end
 
   context "with unspecified quality of protection (qop)" do
     before do


### PR DESCRIPTION
Quality-of-protection values in the 'www-authenticate' header are ignored by httparty whenever they are delivered unquoted. We have observed that several hosts/services return the value without quotes. Furthermore, this [specification](https://www.ietf.org/rfc/rfc2617.txt) seems to indicate that quotes are optional.

What do you think?
