### PR TITLE
add code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pkg/
 *.swp
 /.bundle
 .rvmrc
+coverage

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,1 @@
+SimpleCov.start "test_frameworks"

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,7 @@ group :development do
   gem 'guard-rspec'
   gem 'guard-bundler'
 end
+
+group :test do
+  gem 'simplecov', require: false
+end

--- a/features/steps/env.rb
+++ b/features/steps/env.rb
@@ -1,3 +1,4 @@
+require 'simplecov'
 require 'mongrel'
 require './lib/httparty'
 require 'spec/expectations'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'simplecov'
 $:.push File.expand_path("../lib", __FILE__)
 
 require "httparty"


### PR DESCRIPTION
I think it will be nice to add functionality of [simplecov gem](https://github.com/colszowka/simplecov).
After running

```
bundle exec rake
```

Open httparty/coverage/index.html and you will see something like this ![test coverage](http://oi62.tinypic.com/4tui2p.jpg)
Notice:
[Why .simplecov](https://github.com/colszowka/simplecov#using-simplecov-for-centralized-config)
In .simplecov use [profiler](https://github.com/colszowka/simplecov#profiles) 'test_frameworks', which defined [here](https://github.com/colszowka/simplecov/blob/master/lib/simplecov/defaults.rb#L11).
