### PR TITLE
fix BasicObject

### DIFF
--- a/lib/httparty/core_extensions.rb
+++ b/lib/httparty/core_extensions.rb
@@ -1,12 +1,4 @@
 module HTTParty
-  if defined?(::BasicObject)
-    BasicObject = ::BasicObject #:nodoc:
-  else
-    class BasicObject #:nodoc:
-      instance_methods.each { |m| undef_method m unless m =~ /^__|instance_eval/ }
-    end
-  end
-
   unless defined?(Net::HTTP::Patch)
     class Net::HTTP
       def patch(path, data, initheader = nil, dest = nil, &block) #:nodoc:

--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -1,5 +1,5 @@
 module HTTParty
-  class Response < HTTParty::BasicObject #:nodoc:
+  class Response < BasicObject
     def self.underscore(string)
       string.gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').gsub(/([a-z])([A-Z])/,'\1_\2').downcase
     end


### PR DESCRIPTION
Why we must save BasicObject as a var in HTTParty module (?) :

``` ruby
if defined?(::BasicObject)
  BasicObject = ::BasicObject #:nodoc:
else
```

It is no needed to namespace under HTTParty.
There are no [class names collisions](https://github.com/jnunemaker/httparty/blob/master/History#L214) and tests are running successfully, if we use just 

```
module HTTParty
 class Response < BasicObject
```

This code is not needed

``` ruby
module HTTParty
 if defined?(::BasicObject)
   BasicObject = ::BasicObject #:nodoc:
 else
   class BasicObject #:nodoc:
    instance_methods.each { |m| undef_method m unless m =~ /^__|instance_eval/ }
   end
 end
```

because BasicObject was added in ruby 1.9.0 to ruby-core. [Proof to ruby changelog](http://svn.ruby-lang.org/repos/ruby/tags/v1_9_0_0/ChangeLog), or use google/ruby-doc.org(see 1.9.3, 1.8.7 versions)
Hence, BasicObject is **always** defined on [top](http://ruby-doc.org/core-2.1.5/BasicObject.html) of all classes in ruby version 1.9+
HTTParty supports only 1.9.3+ - [proof1](https://github.com/jnunemaker/httparty/blob/master/README.md#requirements), [proof2](https://github.com/jnunemaker/httparty/blob/master/History#L46)
