### PR TITLE
fix bin/httparty + cucumber tests for it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
-gem 'cucumber', '~> 0.7'
 gem 'fakeweb',  '~> 1.3'
-gem 'rspec',    '~> 3.1'
 gem 'mongrel',  '1.2.0.pre2'
 
 group :development do
@@ -14,5 +12,8 @@ group :development do
 end
 
 group :test do
+  gem 'rspec',    '~> 3.1'
   gem 'simplecov', require: false
+  gem 'aruba'
+  gem 'cucumber', '~> 1.3.17'
 end

--- a/bin/httparty
+++ b/bin/httparty
@@ -99,9 +99,9 @@ else
     when :json
       begin
         require 'json'
-        puts JSON.pretty_generate(response.delegate)
+        puts JSON.pretty_generate(response)
       rescue LoadError
-        puts YAML.dump(response.delegate)
+        puts YAML.dump(response)
       end
     when :xml
       require 'rexml/document'

--- a/features/command_line.feature
+++ b/features/command_line.feature
@@ -1,7 +1,90 @@
+@command_line
 Feature: Command Line
 
   As a developer
   I want to be able to harness the power of HTTParty from the command line
   Because that would make quick testing and debugging easy
-  And 'easy' is my middle name
-  And I'm kidding it's actually 'Danger'!
+
+  Scenario: Show help information
+    When I run `httparty --help`
+    Then the output should contain "-f, --format [FORMAT]"
+
+  Scenario: Make a get request
+    Given a remote deflate service on port '4001'
+    And the response from the service has a body of 'GET request'
+    And that service is accessed at the path '/fun'
+    When I run `httparty http://0.0.0.0:4001/fun`
+    Then the output should contain "GET request"
+
+  Scenario: Make a post request
+    Given a remote deflate service on port '4002'
+    And the response from the service has a body of 'POST request'
+    And that service is accessed at the path '/fun'
+    When I run `httparty http://0.0.0.0:4002/fun --action post --data "a=1&b=2"`
+    Then the output should contain "POST request"
+
+  Scenario: Make a put request
+    Given a remote deflate service on port '4003'
+    And the response from the service has a body of 'PUT request'
+    And that service is accessed at the path '/fun'
+    When I run `httparty http://0.0.0.0:4003/fun --action put --data "a=1&b=2"`
+    Then the output should contain "PUT request"
+
+  Scenario: Make a delete request
+    Given a remote deflate service on port '4004'
+    And the response from the service has a body of 'DELETE request'
+    And that service is accessed at the path '/fun'
+    When I run `httparty http://0.0.0.0:4004/fun --action delete`
+    Then the output should contain "DELETE request"
+
+  Scenario: Set a verbose mode
+    Given a remote deflate service on port '4005'
+    And the response from the service has a body of 'Some request'
+    And that service is accessed at the path '/fun'
+    When I run `httparty http://0.0.0.0:4005/fun --verbose`
+    Then the output should contain "content-length"
+
+  Scenario: Use service with basic authentication
+    Given a remote deflate service on port '4006'
+    And the response from the service has a body of 'Successfull authentication'
+    And that service is accessed at the path '/fun'
+    And that service is protected by Basic Authentication
+    And that service requires the username 'user' with the password 'pass'
+    When I run `httparty http://0.0.0.0:4006/fun --user 'user:pass'`
+    Then the output should contain "Successfull authentication"
+
+  Scenario: Get response in plain format
+    Given a remote deflate service on port '4007'
+    And the response from the service has a body of 'Some request'
+    And that service is accessed at the path '/fun'
+    When I run `httparty http://0.0.0.0:4007/fun --format plain`
+    Then the output should contain "Some request"
+
+  Scenario: Get response in json format
+    Given a remote deflate service on port '4008'
+    Given a remote service that returns '{ "jennings": "waylon", "cash": "johnny" }'
+    And that service is accessed at the path '/service.json'
+    And the response from the service has a Content-Type of 'application/json'
+    When I run `httparty http://0.0.0.0:4008/service.json --format json`
+    Then the output should contain '"jennings": "waylon"'
+
+  Scenario: Get response in xml format
+    Given a remote deflate service on port '4009'
+    Given a remote service that returns '<singer>waylon jennings</singer>'
+    And that service is accessed at the path '/service.xml'
+    And the response from the service has a Content-Type of 'text/xml'
+    When I run `httparty http://0.0.0.0:4009/service.xml --format xml`
+    Then the output should contain "<singer>"
+
+  Scenario: Get response in csv format
+    Given a remote deflate service on port '4010'
+    Given a remote service that returns:
+      """
+      "Last Name","Name"
+      "jennings","waylon"
+      "cash","johnny"
+      """
+    And that service is accessed at the path '/service.csv'
+    And the response from the service has a Content-Type of 'application/csv'
+    When I run `httparty http://0.0.0.0:4010/service.csv --format csv`
+    Then the output should contain '["Last Name", "Name"]'

--- a/features/steps/env.rb
+++ b/features/steps/env.rb
@@ -1,23 +1,27 @@
-require 'simplecov'
 require 'mongrel'
 require './lib/httparty'
 require 'rspec/expectations'
+require 'aruba/cucumber'
 
-Before do
-  def new_port
-    server = TCPServer.new('0.0.0.0', nil)
-    port = server.addr[1]
-  ensure
-    server.close
-  end
-
-  port = ENV["HTTPARTY_PORT"] || new_port
+def run_server(port)
   @host_and_port = "0.0.0.0:#{port}"
   @server = Mongrel::HttpServer.new("0.0.0.0", port)
   @server.run
   @request_options = {}
 end
 
+def new_port
+  server = TCPServer.new('0.0.0.0', nil)
+  port = server.addr[1]
+ensure
+  server.close
+end
+
+Before('~@command_line') do
+  port = ENV["HTTPARTY_PORT"] || new_port
+  run_server(port)
+end
+
 After do
-  @server.stop
+  @server.stop if @server
 end

--- a/features/steps/remote_service_steps.rb
+++ b/features/steps/remote_service_steps.rb
@@ -1,6 +1,6 @@
 Given /a remote service that returns '(.*)'/ do |response_body|
   @handler = BasicMongrelHandler.new
-  Given "the response from the service has a body of '#{response_body}'"
+  step "the response from the service has a body of '#{response_body}'"
 end
 
 Given /^a remote service that returns:$/ do |response_body|
@@ -23,6 +23,11 @@ Given /^that service takes (\d+) seconds to generate a response$/ do |time|
 end
 
 Given /^a remote deflate service$/ do
+  @handler = DeflateHandler.new
+end
+
+Given /^a remote deflate service on port '(\d+)'/ do |port|
+  run_server(port)
   @handler = DeflateHandler.new
 end
 
@@ -55,11 +60,18 @@ Given /that service requires the username '(.*)' with the password '(.*)'/ do |u
   @handler.password = password
 end
 
+# customize aruba cucumber step
+Then /^the output should contain '(.*)'$/ do |expected|
+  assert_partial_output(expected, all_output)
+end
+
 Given /a restricted page at '(.*)'/ do |url|
-  Given "a remote service that returns 'A response I will never see'"
-  And "that service is accessed at the path '#{url}'"
-  And "that service is protected by Basic Authentication"
-  And "that service requires the username 'something' with the password 'secret'"
+  steps %Q{
+    Given a remote service that returns 'A response I will never see'
+    And that service is accessed at the path '#{url}'
+    And that service is protected by Basic Authentication
+    And that service requires the username 'something' with the password 'secret'
+  }
 end
 
 # This joins the server thread, and halts cucumber, so you can actually hit the


### PR DESCRIPTION
It looks, that there is no tests for `bin/httparty`, so i created tests for it.
**Changes:**
1) Without 

``` ruby
puts JSON.pretty_generate(response.delegate)
```

tests are failed ( delegate method is undefined)

2) For testing bin/httparty i am using [aruba - cucumber extension for testing command line apps](https://github.com/cucumber/aruba).

3) We need explicitly run port in featurers:

``` ruby
Scenario: Make a get request
  Given a remote deflate service on port '4001'
```

so, i run mongrel server each scenario with different port for each scenario

``` ruby
Given /^a remote deflate service on port '(\d+)'/ do |port|
 run_server(port)
 @handler = DeflateHandler.new
end
```

Notice: On other tests(which are now on master branch), different port are assigned too for each scenario, but implicitly here:

``` ruby
def new_port
  server = TCPServer.new('0.0.0.0', nil)
  port = server.addr[1]
ensure
  server.close
end
```

4) Also i update cucumber to stable release, and move it to test group in Gemfile because there are a lot of changes since 0.7 cucumber version.
5) 

``` ruby
@server.stop if @server
```

Condition here needed because i don't start server and don't initialze @server in first scenario:

``` ruby
Scenario: Show help information
    When I run `httparty --help`
    Then the output should contain "-f, --format [FORMAT]"
```

6) Also, you can now close another pull request by @dugancathal (https://github.com/jnunemaker/httparty/pull/311) 
