### PR TITLE
remove HTTParty::AllowedFormatsDeprecation

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -16,18 +16,6 @@ require 'httparty/logger/logger'
 
 # @see HTTParty::ClassMethods
 module HTTParty
-  module AllowedFormatsDeprecation
-    def const_missing(const)
-      if const.to_s =~ /AllowedFormats$/
-        Kernel.warn("Deprecated: Use HTTParty::Parser::SupportedFormats")
-        HTTParty::Parser::SupportedFormats
-      else
-        super
-      end
-    end
-  end
-
-  extend AllowedFormatsDeprecation
 
   def self.included(base)
     base.extend ClassMethods
@@ -69,8 +57,6 @@ module HTTParty
   # * :+ssl_ca_path+: see HTTParty::ClassMethods.ssl_ca_path.
 
   module ClassMethods
-
-    extend AllowedFormatsDeprecation
 
     # Turns on logging
     #

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -6,21 +6,6 @@ RSpec.describe HTTParty do
     @klass.instance_eval { include HTTParty }
   end
 
-  describe "AllowedFormats deprecated" do
-    before do
-      allow(Kernel).to receive(:warn)
-    end
-
-    it "warns with a deprecation message" do
-      expect(Kernel).to receive(:warn).with("Deprecated: Use HTTParty::Parser::SupportedFormats")
-      HTTParty::AllowedFormats
-    end
-
-    it "returns HTTPart::Parser::SupportedFormats" do
-      expect(HTTParty::AllowedFormats).to eq(HTTParty::Parser::SupportedFormats)
-    end
-  end
-
   describe "pem" do
     it 'should set the pem content' do
       @klass.pem 'PEM-CONTENT'
@@ -468,13 +453,13 @@ RSpec.describe HTTParty do
       expect(@klass.default_options[:maintain_method_across_redirects]).to be_falsey
     end
   end
-  
+
   describe "#resend_on_redirect" do
     it "sets resend_on_redirect to true by default" do
       @klass.resend_on_redirect
       expect(@klass.default_options[:resend_on_redirect]).to be_truthy
     end
-    
+
     it "sets resend_on_redirect option to false" do
       @klass.resend_on_redirect false
       expect(@klass.default_options[:resend_on_redirect]).to be_falsey


### PR DESCRIPTION
Remove warnings about deprecated `HTTParty::AllowedFormats` 
because [there are 5 years since this commit.](https://github.com/jnunemaker/httparty/commit/d0d88fecfdd7528fa8bd8d12004f686318f3486c)
(now nobody knows about `HTTParty::AllowedFormats` ,
 all use `HTTParty::Parser::SupportedFormats`
