### PR TITLE
Fix specs to RSpec 3.1.7 syntax with Transpec

### DIFF
--- a/spec/httparty/net_digest_auth_spec.rb
+++ b/spec/httparty/net_digest_auth_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Net::HTTPHeader::DigestAuthenticator do
     end
 
     it "should set cookie header" do
-      cookie_header.should include('custom-cookie=1234567')
+      expect(cookie_header).to include('custom-cookie=1234567')
     end
   end
 
@@ -38,7 +38,7 @@ RSpec.describe Net::HTTPHeader::DigestAuthenticator do
     end
 
     it "should set empty cookie header array" do
-      cookie_header.should eql []
+      expect(cookie_header).to eql []
     end
   end
 

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe HTTParty::Request do
       @request.send(:setup_raw_request)
 
       raw_request = @request.instance_variable_get(:@raw_request)
-      raw_request.instance_variable_get(:@header)['cookie'].should eql ["custom-cookie=1234567"]
+      expect(raw_request.instance_variable_get(:@header)['cookie']).to eql ["custom-cookie=1234567"]
     end
 
     it 'should merge cookies from setup_digest_auth and request' do
@@ -161,7 +161,7 @@ RSpec.describe HTTParty::Request do
       @request.send(:setup_raw_request)
 
       raw_request = @request.instance_variable_get(:@raw_request)
-      raw_request.instance_variable_get(:@header)['cookie'].should eql ['request-cookie=test', 'custom-cookie=1234567']
+      expect(raw_request.instance_variable_get(:@header)['cookie']).to eql ['request-cookie=test', 'custom-cookie=1234567']
     end
 
     it 'should use body_stream when configured' do


### PR DESCRIPTION
Fix Rspec syntax after merging https://github.com/jnunemaker/httparty/pull/313
This conversion is done by Transpec 3.0.3 with the following command:
    transpec
- 4 conversions
  from: obj.should
    to: expect(obj).to

For more details: https://github.com/yujinakayama/transpec#supported-conversions
