### PR TITLE
fix merge SupportedFormats in examples

### DIFF
--- a/examples/nokogiri_html_parser.rb
+++ b/examples/nokogiri_html_parser.rb
@@ -7,8 +7,6 @@ require File.join(dir, 'httparty')
 require 'pp'
 
 class HtmlParserIncluded < HTTParty::Parser
-  SupportedFormats.merge!('text/html' => :html)
-
   def html
     Nokogiri::HTML(body)
   end


### PR DESCRIPTION
Merging text/html to `SupportedFormats` is not needed, because [text/html is already exists in it.](https://github.com/jnunemaker/httparty/blob/master/lib/httparty/parser.rb#L47)
Notice:
I can add rspec to this example if you want (there is no tests for any examples folder on master branch now), but it will require nokogiri gem in Gemfile test group, as a dependency.
