### PR TITLE
remove HTTParty namespace for included module

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -19,7 +19,7 @@ module HTTParty
 
   def self.included(base)
     base.extend ClassMethods
-    base.send :include, HTTParty::ModuleInheritableAttributes
+    base.send :include, ModuleInheritableAttributes
     base.send(:mattr_inheritable, :default_options)
     base.send(:mattr_inheritable, :default_cookies)
     base.instance_variable_set("@default_options", {})


### PR DESCRIPTION
HTTParty namespace is not needed, because `ModuleInheritableAttributes` is on the same namespace, as a `included` ( all have `HTTParty` in parent stack)
