### PR TITLE
Replace URI.encode with ERB::Util.url_encode

### DIFF
--- a/lib/httparty/hash_conversions.rb
+++ b/lib/httparty/hash_conversions.rb
@@ -30,7 +30,7 @@ module HTTParty
       elsif value.respond_to?(:to_hash)
         stack << [key,value.to_hash]
       else
-        param << "#{key}=#{URI.encode(value.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))}&"
+        param << "#{key}=#{ERB::Util.url_encode(value.to_s)}&"
       end
 
       stack.each do |parent, hash|

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -19,7 +19,7 @@ module HTTParty
         if value.nil?
           key.to_s
         elsif value.respond_to?(:to_ary)
-          value.to_ary.map {|v| "#{key}=#{URI.encode(v.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))}"}
+          value.to_ary.map {|v| "#{key}=#{ERB::Util.url_encode(v.to_s)}"}
         else
           HashConversions.to_params(key => value)
         end


### PR DESCRIPTION
URI.encode is an alias for URI.escape which has been deprecated. There
is a great stackoverflow question discussing this deprecation and
possible replacements, http://stackoverflow.com/a/2832003/1769125. 

After some testing I decided that ERB::Util.url_encode was the best choice as
it most closely mirrored the current implementation.

```ruby
foo = "http://google.com?query=hello"

old_way = URI.escape(foo, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
#=> "http%3A%2F%2Fgoogle.com%3Fquery%3Dhello"

new_way = ERB::Util.url_encode(foo)
#=> "http%3A%2F%2Fgoogle.com%3Fquery%3Dhello"

old_way == new_way
#=> true
```