### PR TITLE
refactor HTTParty::HashConversions.to_params

### DIFF
--- a/lib/httparty/hash_conversions.rb
+++ b/lib/httparty/hash_conversions.rb
@@ -12,9 +12,7 @@ module HTTParty
     #   }.to_params
     #     #=> "name=Bob&address[city]=Ruby Central&address[phones][]=111-111-1111&address[phones][]=222-222-2222&address[street]=111 Ruby Ave."
     def self.to_params(hash)
-      params = hash.to_hash.map { |k,v| normalize_param(k,v) }.join
-      params.chop! # trailing &
-      params
+      hash.to_hash.map { |k,v| normalize_param(k,v) }.join.chop
     end
 
     # @param key<Object> The key for the param.


### PR DESCRIPTION
1) I think using dangerous ```chop!``` is unnecessary , you can use this:
```ruby
def self.to_params(hash)
 params = hash.to_hash.map { |k,v| normalize_param(k,v) }.join
 params.chop
end
```
2) Using ```params``` variable is not necessary, using chop in chain is more concise and used in the same way as map, join method
3) Tests are added in previous pr #367 