### PR TITLE
remote_ip to response

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -6,6 +6,7 @@ require 'zlib'
 require 'multi_xml'
 require 'json'
 require 'csv'
+require 'socket'
 
 require 'httparty/module_inheritable_attributes'
 require 'httparty/cookie_hash'

--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -27,6 +27,15 @@ module HTTParty
       Response
     end
 
+    def socket_info
+      ::Socket.getaddrinfo @request.last_uri.host, @request.last_uri.scheme, nil, :STREAM
+    end
+
+    def remote_ip
+      domain, port, ip = socket_info.first
+      ip
+    end
+
     def code
       response.code.to_i
     end


### PR DESCRIPTION
I want to implement getting remote ip for response host like this:
```ruby
response = HTTParty.get 'http://google.ru'
response.remote_ip
```
```shell
=> "173.194.40.248"
```
I don't find this ability in net/http lib, only in socket library.
I am also, don't created tests, because i am not sure, that my implementation looks clearly.
@jnunemaker , what you think about it ?