### PR TITLE
Remove incorrect requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ gem install httparty
 
 * Ruby 1.9.3 or higher
 * multi_xml
-* You like to party!
 
 ## Examples
 

--- a/httparty.gemspec
+++ b/httparty.gemspec
@@ -18,9 +18,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'json',      "~> 1.8"
   s.add_dependency 'multi_xml', ">= 0.5.2"
 
-  # If this line is removed, all hard partying will cease.
-  s.post_install_message = "When you HTTParty, you must party hard!"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
We are successfully using `httparty` in production and it runs fine without any partying.

Removes incorrect requirements from `README.md` and `httparty.gemspec`.

See also #139, #211, #236, #237, #294, #315, #321.