### PR TITLE
Replace Ruby's URI with Addressable::URI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 gem 'rake'
 gem 'fakeweb',  '~> 1.3'
 gem 'mongrel',  '1.2.0.pre2'
+gem 'addressable'
 
 group :development do
   gem 'guard'

--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -1,7 +1,7 @@
 require 'pathname'
 require 'net/http'
 require 'net/https'
-require 'uri'
+require "addressable/uri"
 require 'zlib'
 require 'multi_xml'
 require 'json'
@@ -16,6 +16,7 @@ require 'httparty/logger/logger'
 
 # @see HTTParty::ClassMethods
 module HTTParty
+
   def self.included(base)
     base.extend ClassMethods
     base.send :include, ModuleInheritableAttributes

--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -61,7 +61,7 @@ module HTTParty
     attr_reader :uri, :options
 
     def initialize(uri, options = {})
-      raise ArgumentError, "uri must be a URI, not a #{uri.class}" unless uri.is_a? URI
+      raise ArgumentError, "uri must be a Addressable::URI, not a #{uri.class}" unless uri.is_a?(Addressable::URI)
 
       @uri = uri
       @options = options
@@ -69,10 +69,11 @@ module HTTParty
 
     def connection
       host = clean_host(uri.host)
+      default_port = uri.scheme == 'https' ? 443 : 80
       if options[:http_proxyaddr]
-        http = Net::HTTP.new(host, uri.port, options[:http_proxyaddr], options[:http_proxyport], options[:http_proxyuser], options[:http_proxypass])
+        http = Net::HTTP.new(host, uri.port || default_port, options[:http_proxyaddr], options[:http_proxyport], options[:http_proxyuser], options[:http_proxypass])
       else
-        http = Net::HTTP.new(host, uri.port)
+        http = Net::HTTP.new(host, uri.port || default_port)
       end
 
       http.use_ssl = ssl_implied?(uri)
@@ -133,7 +134,7 @@ module HTTParty
     end
 
     def ssl_implied?(uri)
-      uri.port == 443 || uri.instance_of?(URI::HTTPS)
+      uri.port == 443 || uri.scheme == 'https'
     end
 
     def attach_ssl_certificates(http, options)

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -12,7 +12,7 @@ module HTTParty
       Net::HTTP::Copy
     ]
 
-    SupportedURISchemes  = [URI::HTTP, URI::HTTPS, URI::Generic]
+    SupportedURISchemes  = ['http', 'https', nil]
 
     NON_RAILS_QUERY_STRING_NORMALIZER = proc do |query|
       Array(query).sort_by { |a| a[0].to_s }.map do |key, value|
@@ -44,7 +44,7 @@ module HTTParty
     end
 
     def path=(uri)
-      @path = URI(uri)
+      @path = Addressable::URI.parse(uri)
     end
 
     def request_uri(uri)
@@ -63,14 +63,14 @@ module HTTParty
         path.path = last_uri_host + path.path
       end
 
-      new_uri = path.relative? ? URI.parse("#{base_uri}#{path}") : path.clone
+      new_uri = path.relative? ? Addressable::URI.parse("#{base_uri}#{path}") : path.clone
 
       # avoid double query string on redirects [#12]
       unless redirect
         new_uri.query = query_string(new_uri)
       end
 
-      unless SupportedURISchemes.include? new_uri.class
+      unless SupportedURISchemes.include? new_uri.scheme
         raise UnsupportedURIScheme, "'#{new_uri}' Must be HTTP, HTTPS or Generic"
       end
 

--- a/spec/httparty/connection_adapter_spec.rb
+++ b/spec/httparty/connection_adapter_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
 
 RSpec.describe HTTParty::ConnectionAdapter do
   describe "initialization" do
-    let(:uri) { URI 'http://www.google.com' }
+    let(:uri) { Addressable::URI.parse 'http://www.google.com' }
     it "takes a URI as input" do
       HTTParty::ConnectionAdapter.new(uri)
     end
@@ -29,6 +29,7 @@ RSpec.describe HTTParty::ConnectionAdapter do
       adapter = HTTParty::ConnectionAdapter.new(uri, options)
       expect(adapter.options).to be options
     end
+
   end
 
   describe ".call" do
@@ -47,7 +48,7 @@ RSpec.describe HTTParty::ConnectionAdapter do
   end
 
   describe '#connection' do
-    let(:uri) { URI 'http://www.google.com' }
+    let(:uri) { Addressable::URI.parse 'http://www.google.com' }
     let(:options) { Hash.new }
     let(:adapter) { HTTParty::ConnectionAdapter.new(uri, options) }
 
@@ -56,12 +57,12 @@ RSpec.describe HTTParty::ConnectionAdapter do
       it { is_expected.to be_an_instance_of Net::HTTP }
 
       context "using port 80" do
-        let(:uri) { URI 'http://foobar.com' }
+        let(:uri) { Addressable::URI.parse 'http://foobar.com' }
         it { is_expected.not_to use_ssl }
       end
 
       context "when dealing with ssl" do
-        let(:uri) { URI 'https://foobar.com' }
+        let(:uri) { Addressable::URI.parse 'https://foobar.com' }
 
         context "uses the system cert_store, by default" do
           let!(:system_cert_store) do
@@ -80,7 +81,7 @@ RSpec.describe HTTParty::ConnectionAdapter do
         end
 
         context "using port 443 for ssl" do
-          let(:uri) { URI 'https://api.foo.com/v1:443' }
+          let(:uri) { Addressable::URI.parse 'https://api.foo.com/v1:443' }
           it { is_expected.to use_ssl }
         end
 
@@ -89,7 +90,7 @@ RSpec.describe HTTParty::ConnectionAdapter do
         end
 
         context "https scheme with non-standard port" do
-          let(:uri) { URI 'https://foobar.com:123456' }
+          let(:uri) { Addressable::URI.parse 'https://foobar.com:123456' }
           it { is_expected.to use_ssl }
         end
 
@@ -103,7 +104,7 @@ RSpec.describe HTTParty::ConnectionAdapter do
       end
 
       context "when dealing with IPv6" do
-        let(:uri) { URI 'http://[fd00::1]' }
+        let(:uri) { Addressable::URI.parse 'http://[fd00::1]' }
 
         it "strips brackets from the address" do
           expect(subject.address).to eq('fd00::1')
@@ -326,7 +327,7 @@ RSpec.describe HTTParty::ConnectionAdapter do
       end
 
       context 'when not providing a proxy address' do
-        let(:uri) { URI 'http://proxytest.com' }
+        let(:uri) { Addressable::URI.parse 'http://proxytest.com' }
 
         it "does not pass any proxy parameters to the connection" do
           http = Net::HTTP.new("proxytest.com")
@@ -354,7 +355,7 @@ RSpec.describe HTTParty::ConnectionAdapter do
         let(:options) { {pem: pem, pem_password: "password"} }
 
         context "when scheme is https" do
-          let(:uri) { URI 'https://google.com' }
+          let(:uri) { Addressable::URI.parse 'https://google.com' }
           let(:cert) { double("OpenSSL::X509::Certificate") }
           let(:key) { double("OpenSSL::PKey::RSA") }
 
@@ -382,7 +383,7 @@ RSpec.describe HTTParty::ConnectionAdapter do
         end
 
         context "when scheme is not https" do
-          let(:uri) { URI 'http://google.com' }
+          let(:uri) { Addressable::URI.parse 'http://google.com' }
           let(:http) { Net::HTTP.new(uri) }
 
           before do
@@ -405,7 +406,7 @@ RSpec.describe HTTParty::ConnectionAdapter do
         let(:options) { {p12: p12, p12_password: "password"} }
 
         context "when scheme is https" do
-          let(:uri) { URI 'https://google.com' }
+          let(:uri) { Addressable::URI.parse 'https://google.com' }
           let(:pkcs12) { double("OpenSSL::PKCS12", certificate: cert, key: key) }
           let(:cert) { double("OpenSSL::X509::Certificate") }
           let(:key) { double("OpenSSL::PKey::RSA") }
@@ -433,7 +434,7 @@ RSpec.describe HTTParty::ConnectionAdapter do
         end
 
         context "when scheme is not https" do
-          let(:uri) { URI 'http://google.com' }
+          let(:uri) { Addressable::URI.parse 'http://google.com' }
           let(:http) { Net::HTTP.new(uri) }
 
           before do

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -173,36 +173,36 @@ RSpec.describe HTTParty::Request do
   describe "#uri" do
     context "redirects" do
       it "returns correct path when the server sets the location header to a filename" do
-        @request.last_uri = URI.parse("http://example.com/foo/bar")
-        @request.path = URI.parse("bar?foo=bar")
+        @request.last_uri = Addressable::URI.parse("http://example.com/foo/bar")
+        @request.path = Addressable::URI.parse("bar?foo=bar")
         @request.redirect = true
 
-        expect(@request.uri).to eq(URI.parse("http://example.com/foo/bar?foo=bar"))
+        expect(@request.uri).to eq(Addressable::URI.parse("http://example.com/foo/bar?foo=bar"))
       end
 
       context "location header is an absolute path" do
         it "returns correct path when location has leading slash" do
-          @request.last_uri = URI.parse("http://example.com/foo/bar")
-          @request.path = URI.parse("/bar?foo=bar")
+          @request.last_uri = Addressable::URI.parse("http://example.com/foo/bar")
+          @request.path = Addressable::URI.parse("/bar?foo=bar")
           @request.redirect = true
 
-          expect(@request.uri).to eq(URI.parse("http://example.com/bar?foo=bar"))
+          expect(@request.uri).to eq(Addressable::URI.parse("http://example.com/bar?foo=bar"))
         end
 
         it "returns the correct path when location has no leading slash" do
-          @request.last_uri = URI.parse("http://example.com")
-          @request.path = URI.parse("bar/")
+          @request.last_uri = Addressable::URI.parse("http://example.com")
+          @request.path = Addressable::URI.parse("bar/")
           @request.redirect = true
 
-          expect(@request.uri).to eq(URI.parse("http://example.com/bar/"))
+          expect(@request.uri).to eq(Addressable::URI.parse("http://example.com/bar/"))
         end
       end
       it "returns correct path when the server sets the location header to a full uri" do
-        @request.last_uri = URI.parse("http://example.com/foo/bar")
-        @request.path = URI.parse("http://example.com/bar?foo=bar")
+        @request.last_uri = Addressable::URI.parse("http://example.com/foo/bar")
+        @request.path = Addressable::URI.parse("http://example.com/bar?foo=bar")
         @request.redirect = true
 
-        expect(@request.uri).to eq(URI.parse("http://example.com/bar?foo=bar"))
+        expect(@request.uri).to eq(Addressable::URI.parse("http://example.com/bar?foo=bar"))
       end
     end
 

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -376,7 +376,7 @@ RSpec.describe HTTParty do
       expect(connection_adapter).to receive(:call) { |u, o|
         expect(o[:connection_adapter_options]).to eq(connection_adapter_options)
         HTTParty::ConnectionAdapter.call(u, o)
-      }.with(URI.parse(uri), kind_of(Hash))
+      }.with(Addressable::URI.parse(uri), kind_of(Hash))
       FakeWeb.register_uri(:get, uri, body: 'stuff')
       @klass.connection_adapter connection_adapter, connection_adapter_options
       expect(@klass.get(uri).parsed_response).to eq('stuff')


### PR DESCRIPTION
Addressable is a replacement for the URI implementation that is part of
Ruby's standard library. It more closely conforms to RFC 3986, RFC 3987,
and RFC 6570 (level 4), additionally providing support for IRIs and URI
templates. http://addressable.rubyforge.org/

Fixes #394