### PR TITLE
Require ERB to prevent errors in HashConversions

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -6,6 +6,7 @@ require 'zlib'
 require 'multi_xml'
 require 'json'
 require 'csv'
+require 'erb'
 
 require 'httparty/module_inheritable_attributes'
 require 'httparty/cookie_hash'


### PR DESCRIPTION
Just a quick fix for an issue I was experiencing.  The error I was encountering was from line 34 of `hash_conversions.rb`.

This address [Issue 398](https://github.com/jnunemaker/httparty/issues/398)

Output of `bundle exec rake`:

```
Finished in 1.26 seconds (files took 0.2498 seconds to load)
414 examples, 0 failures

Randomized with seed 49033

Coverage report generated for RSpec to /Users/forrest.fleming/httparty/coverage. 664 / 700 LOC (94.86%) covered.
```
...
```
31 scenarios (31 passed)
155 steps (155 passed)
0m14.276s
```