### PR TITLE
Allow setting a custom URI adapter

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -49,6 +49,7 @@ module HTTParty
   # * :+maintain_method_across_redirects+: see HTTParty::ClassMethods.maintain_method_across_redirects.
   # * :+no_follow+: see HTTParty::ClassMethods.no_follow.
   # * :+parser+: see HTTParty::ClassMethods.parser.
+  # * :+uri_adapter+: see HTTParty::ClassMethods.uri_adapter
   # * :+connection_adapter+: see HTTParty::ClassMethods.connection_adapter.
   # * :+pem+: see HTTParty::ClassMethods.pem.
   # * :+query_string_normalizer+: see HTTParty::ClassMethods.query_string_normalizer
@@ -417,6 +418,17 @@ module HTTParty
         default_options[:parser] = custom_parser
         validate_format
       end
+    end
+
+    # Allows setting a custom URI adapter.
+    #
+    #   class Foo
+    #     include HTTParty
+    #     uri_adapter Addressable::URI
+    #   end
+    def uri_adapter(uri_adapter)
+      raise ArgumentError, 'The URI adapter should respond to #parse' unless uri_adapter.respond_to?(:parse)
+      default_options[:uri_adapter] = uri_adapter
     end
 
     # Allows setting a custom connection_adapter for the http connections

--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -69,10 +69,11 @@ module HTTParty
 
     def connection
       host = clean_host(uri.host)
+      default_port = uri.scheme == 'https' ? 443 : 80
       if options[:http_proxyaddr]
-        http = Net::HTTP.new(host, uri.port, options[:http_proxyaddr], options[:http_proxyport], options[:http_proxyuser], options[:http_proxypass])
+        http = Net::HTTP.new(host, uri.port || default_port, options[:http_proxyaddr], options[:http_proxyport], options[:http_proxyuser], options[:http_proxypass])
       else
-        http = Net::HTTP.new(host, uri.port)
+        http = Net::HTTP.new(host, uri.port || default_port)
       end
 
       http.use_ssl = ssl_implied?(uri)
@@ -133,7 +134,7 @@ module HTTParty
     end
 
     def ssl_implied?(uri)
-      uri.port == 443 || uri.instance_of?(URI::HTTPS)
+      uri.port == 443 || uri.scheme == 'https'
     end
 
     def attach_ssl_certificates(http, options)

--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -70,7 +70,7 @@ module HTTParty
 
     def connection
       host = clean_host(uri.host)
-      port = uri.port or uri.scheme == 'https' ? 443 : 80
+      port = uri.port || (uri.scheme == 'https' ? 443 : 80)
       if options[:http_proxyaddr]
         http = Net::HTTP.new(host, port, options[:http_proxyaddr], options[:http_proxyport], options[:http_proxyuser], options[:http_proxypass])
       else

--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -70,11 +70,11 @@ module HTTParty
 
     def connection
       host = clean_host(uri.host)
-      default_port = uri.scheme == 'https' ? 443 : 80
+      port = uri.port or uri.scheme == 'https' ? 443 : 80
       if options[:http_proxyaddr]
-        http = Net::HTTP.new(host, uri.port || default_port, options[:http_proxyaddr], options[:http_proxyport], options[:http_proxyuser], options[:http_proxypass])
+        http = Net::HTTP.new(host, port, options[:http_proxyaddr], options[:http_proxyport], options[:http_proxyuser], options[:http_proxypass])
       else
-        http = Net::HTTP.new(host, uri.port || default_port)
+        http = Net::HTTP.new(host, port)
       end
 
       http.use_ssl = ssl_implied?(uri)

--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -61,7 +61,8 @@ module HTTParty
     attr_reader :uri, :options
 
     def initialize(uri, options = {})
-      raise ArgumentError, "uri must be a URI, not a #{uri.class}" unless uri.is_a? URI
+      uri_adapter = options[:uri_adapter] || URI
+      raise ArgumentError, "uri must be a #{uri_adapter}, not a #{uri.class}" unless uri.is_a? uri_adapter
 
       @uri = uri
       @options = options

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -37,6 +37,7 @@ module HTTParty
         default_params: {},
         follow_redirects: true,
         parser: Parser,
+        uri_adapter: URI,
         connection_adapter: ConnectionAdapter
       }.merge(o)
       self.path = path
@@ -90,13 +91,15 @@ module HTTParty
     end
 
     def URI uri
-      if uri.is_a?(URI)
+      uri_adapter = options[:uri_adapter]
+
+      if uri.is_a?(uri_adapter)
         uri
       elsif uri = String.try_convert(uri)
-        URI.parse uri
+        uri_adapter.parse uri
       else
         raise ArgumentError,
-          "bad argument (expected URI object or URI string)"
+          "bad argument (expected #{uri_adapter} object or URI string)"
       end
     end
 

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -73,7 +73,7 @@ module HTTParty
         path.path = last_uri_host + path.path
       end
 
-      new_uri = path.relative? ? URI.parse("#{base_uri}#{path}") : path.clone
+      new_uri = path.relative? ? options[:uri_adapter].parse("#{base_uri}#{path}") : path.clone
 
       # avoid double query string on redirects [#12]
       unless redirect

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -45,7 +45,16 @@ module HTTParty
     end
 
     def path=(uri)
-      @path = URI(uri)
+      uri_adapter = options[:uri_adapter]
+
+      @path = if uri.is_a?(uri_adapter)
+        uri
+      elsif String.try_convert(uri)
+        uri_adapter.parse uri
+      else
+        raise ArgumentError,
+          "bad argument (expected #{uri_adapter} object or URI string)"
+      end
     end
 
     def request_uri(uri)
@@ -88,19 +97,6 @@ module HTTParty
 
     def parser
       options[:parser]
-    end
-
-    def URI uri
-      uri_adapter = options[:uri_adapter]
-
-      if uri.is_a?(uri_adapter)
-        uri
-      elsif uri = String.try_convert(uri)
-        uri_adapter.parse uri
-      else
-        raise ArgumentError,
-          "bad argument (expected #{uri_adapter} object or URI string)"
-      end
     end
 
     def connection_adapter

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -12,7 +12,7 @@ module HTTParty
       Net::HTTP::Copy
     ]
 
-    SupportedURISchemes  = ['http', 'https', nil]
+    SupportedURISchemes  = ['http', 'https', 'webcal', nil]
 
     NON_RAILS_QUERY_STRING_NORMALIZER = proc do |query|
       Array(query).sort_by { |a| a[0].to_s }.map do |key, value|

--- a/spec/httparty/connection_adapter_spec.rb
+++ b/spec/httparty/connection_adapter_spec.rb
@@ -449,6 +449,20 @@ RSpec.describe HTTParty::ConnectionAdapter do
           end
         end
       end
+
+      context "when uri port is not defined" do
+        context "falls back to 80 port on http" do
+          let(:uri) { URI 'http://foobar.com' }
+          before { allow(uri).to receive(:port).and_return(nil) }
+          it { expect(subject.port).to be 80 }
+        end
+
+        context "falls back to 443 port on https" do
+          let(:uri) { URI 'https://foobar.com' }
+          before { allow(uri).to receive(:port).and_return(nil) }
+          it { expect(subject.port).to be 443 }
+        end
+      end
     end
   end
 end

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -806,9 +806,11 @@ RSpec.describe HTTParty do
     end
 
     it "should accept webcal URIs" do
-      stub_http_response_with('google.html')
+      uri = 'http://google.com/'
+      FakeWeb.register_uri(:get, uri, body: 'stuff')
+      uri = 'webcal://google.com/'
       expect do
-        HTTParty.get('webcal://google.com')
+        HTTParty.get(uri)
       end.not_to raise_error
     end
 

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -351,6 +351,45 @@ RSpec.describe HTTParty do
     end
   end
 
+  describe "uri_adapter" do
+
+    require 'forwardable'
+    class CustomURIAdaptor
+      extend Forwardable
+      def_delegators :@uri, :userinfo, :relative?, :query, :query=, :scheme, :path, :host, :port
+
+      def initialize uri
+        @uri = uri
+      end
+
+      def self.parse uri
+        new URI.parse uri
+      end
+    end
+
+    let(:uri_adapter) { CustomURIAdaptor }
+
+    it "should set the uri_adapter" do
+      @klass.uri_adapter uri_adapter
+      expect(@klass.default_options[:uri_adapter]).to be uri_adapter
+    end
+
+    it "should raise an ArgumentError if uri_adapter doesn't implement parse method" do
+      expect do
+        @klass.uri_adapter double()
+      end.to raise_error(ArgumentError)
+    end
+
+
+    it "should process a request with a uri instance parsed from the uri_adapter" do
+      uri = 'http://foo.com/bar'
+      FakeWeb.register_uri(:get, uri, body: 'stuff')
+      @klass.uri_adapter uri_adapter
+      expect(@klass.get(uri).parsed_response).to eq('stuff')
+    end
+
+  end
+
   describe "connection_adapter" do
     let(:uri) { 'http://google.com/api.json' }
     let(:connection_adapter) { double('CustomConnectionAdapter') }


### PR DESCRIPTION
This option allows you to roll out fancier URI implementations like the one
offered by the Addressable gem.

Addressable is a replacement for the URI implementation that is part of
Ruby's standard library. It more closely conforms to RFC 3986, RFC 3987,
and RFC 6570 (level 4), additionally providing support for IRIs and URI
templates. http://addressable.rubyforge.org/

*Sample Usage:*

```javascript
require 'httparty'
require 'addressable/uri'
require 'pp'

class Foo
  include HTTParty
  uri_adapter Addressable::URI
end

pp Foo.get('http://svd_identity.spinninpodcasts.com/rss')
```

Fixes #394 