### PR TITLE
require 'erb' in hash_conversions.rb

### DIFF
--- a/lib/httparty/hash_conversions.rb
+++ b/lib/httparty/hash_conversions.rb
@@ -1,3 +1,4 @@
+require 'erb'
 module HTTParty
   module HashConversions
     # @return <String> This hash as a query string
@@ -30,7 +31,7 @@ module HTTParty
       elsif value.respond_to?(:to_hash)
         stack << [key, value.to_hash]
       else
-        param << "#{key}=#{ERB::Util.url_encode(value.to_s)}&"
+        param << "#{key}=#{ERB::Util.url_encode(value.to_s)}&"  # must require 'erb' for this to work
       end
 
       stack.each do |parent, hash|


### PR DESCRIPTION
I had issues using this with the klout and bit.ly gems and APIs on Windows. Adding `require 'erb'` at the top in this library fixed the problem I was having.

Was following this tutorial: http://tutorials.jumpstartlab.com/projects/microblogger.html#get-ready
(Iterations 5 and 6 were where the problems occurred.