### PR TITLE
Use JSON.parse instead of JSON.load

### DIFF
--- a/lib/httparty/parser.rb
+++ b/lib/httparty/parser.rb
@@ -113,7 +113,7 @@ module HTTParty
     end
 
     def json
-      JSON.parse(body, :quirks_mode => true)
+      JSON.parse(body, :quirks_mode => true, :allow_nan => true)
     end
 
     def csv

--- a/lib/httparty/parser.rb
+++ b/lib/httparty/parser.rb
@@ -113,7 +113,7 @@ module HTTParty
     end
 
     def json
-      JSON.load(body, nil)
+      JSON.parse(body, :quirks_mode => true)
     end
 
     def csv

--- a/spec/httparty/parser_spec.rb
+++ b/spec/httparty/parser_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe HTTParty::Parser do
     end
 
     it "parses json with JSON" do
-      expect(JSON).to receive(:load).with('body', nil)
+      expect(JSON).to receive(:parse).with('body', :quirks_mode => true)
       subject.send(:json)
     end
 

--- a/spec/httparty/parser_spec.rb
+++ b/spec/httparty/parser_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe HTTParty::Parser do
     end
 
     it "parses json with JSON" do
-      expect(JSON).to receive(:parse).with('body', :quirks_mode => true)
+      expect(JSON).to receive(:parse).with('body', :quirks_mode => true, :allow_nan => true)
       subject.send(:json)
     end
 


### PR DESCRIPTION
JSON.load is unsafe to use on untrusted user input:
https://www.ruby-lang.org/en/news/2013/02/22/json-dos-cve-2013-0269/
http://ruby-doc.org/stdlib-2.0.0/libdoc/json/rdoc/JSON.html#method-i-load
JSON.parse should be used instead.

This change enables quirks_mode so as to reduce breakages from this
change. Quirks mode enables the parsing of json values other than
objects or arrays, which matches the behaviour of JSON.load.

Note: there still may be breaking changes due to the differences between
load and parse:
- nil and empty string are not parsed by parse, they are parsed as nil
  by load
- NaN is not parsed by parse, it is parsed as NaN by load
- parse does not allow nesting of more than 100 to prevent stack level
  too deep errors, load has no such limit