### PR TITLE
Add version output

### DIFF
--- a/bin/httparty
+++ b/bin/httparty
@@ -62,6 +62,12 @@ OptionParser.new do |o|
     puts o
     exit
   end
+
+  o.on("--version", "Show the version") do |ver|
+    puts "The current version is: #{HTTParty::VERSION}"
+    exit
+  end
+
 end.parse!
 
 if ARGV.empty?

--- a/bin/httparty
+++ b/bin/httparty
@@ -63,11 +63,10 @@ OptionParser.new do |o|
     exit
   end
 
-  o.on("--version", "Show the version") do |ver|
-    puts "The current version is: #{HTTParty::VERSION}"
+  o.on("--version", "Show HTTParty version") do |ver|
+    puts "Version: #{HTTParty::VERSION}"
     exit
   end
-
 end.parse!
 
 if ARGV.empty?

--- a/features/command_line.feature
+++ b/features/command_line.feature
@@ -9,6 +9,11 @@ Feature: Command Line
     When I run `httparty --help`
     Then the output should contain "-f, --format [FORMAT]"
 
+  Scenario: Show httparty version at command line
+    When I run `httparty --version`
+    Then the output should contain "The current version is:"
+    And the output should not contain "You need to provide a URL"
+
   Scenario: Make a get request
     Given a remote deflate service on port '4001'
     And the response from the service has a body of 'GET request'

--- a/features/command_line.feature
+++ b/features/command_line.feature
@@ -9,9 +9,9 @@ Feature: Command Line
     When I run `httparty --help`
     Then the output should contain "-f, --format [FORMAT]"
 
-  Scenario: Show httparty version at command line
+  Scenario: Show current version
     When I run `httparty --version`
-    Then the output should contain "The current version is:"
+    Then the output should contain "Version:"
     And the output should not contain "You need to provide a URL"
 
   Scenario: Make a get request


### PR DESCRIPTION
Added functionality that allows users to type '--version' at the command line and be presented with the current working version on their machine.

Also added cucumber feature tests to ensure the functionality is working correctly.