### PR TITLE
add body UTF-8 check before attempting strip

### DIFF
--- a/lib/httparty/parser.rb
+++ b/lib/httparty/parser.rb
@@ -98,7 +98,7 @@ module HTTParty
     # @return [Object] the parsed body
     # @return [nil] when the response body is nil, an empty string, spaces only or "null"
     def parse
-      return nil if body.nil? || body.strip.empty? || body == "null"
+      return nil if body.nil? || (body.valid_encoding? && body.strip.empty?) || body == "null"
       if supports_format?
         parse_supported_format
       else


### PR DESCRIPTION
repro steps:

irb(main):001:0> require 'httparty'
=> true
irb(main):002:0> url = "https://archive.org/download/beowulf/Beowulf.jpg"
=> "https://archive.org/download/beowulf/Beowulf.jpg"
irb(main):003:0> HTTParty.get(url).parsed_response
xplosions:

/.gem/ruby/2.1.5/gems/httparty-0.13.5/lib/httparty/parser.rb:103:in `strip': invalid byte sequence in UTF-8 (ArgumentError)