### PR TITLE
update code example in README to avoid confusion w base_uri method

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ gem install httparty
 
 ```ruby
 # Use the class methods to get down to business quickly
-response = HTTParty.get('https://api.stackexchange.com/2.2/questions?site=stackoverflow')
+response = HTTParty.get('http://api.stackexchange.com/2.2/questions?site=stackoverflow')
 
 puts response.body, response.code, response.message, response.headers.inspect
 


### PR DESCRIPTION

the code example in the README:
```ruby
# Use the class methods to get down to business quickly
response = HTTParty.get('https://api.stackexchange.com/2.2/questions?site=stackoverflow')
```

uses `https://` instead of `http://`.

this makes the following example using `base_uri` appear to default to prefixing the base uri with `https://`.  it's my understanding that the default is `http://`.

```ruby
base_uri 'api.stackexchange.com'
```

the PR updates `https://` to be `http://` in the first example to avoid confusion.
