### PR TITLE
Added support for RFC2617 MD5-sess algorithm type

### DIFF
--- a/features/digest_authentication.feature
+++ b/features/digest_authentication.feature
@@ -18,3 +18,13 @@ Feature:  Digest Authentication
        | username | password   |
        | jcash    | maninblack |
     Then the return value should match 'Digest Authenticated Page'
+
+  Scenario: Passing proper credentials to a page requiring Digest Authentication using md5-sess algorithm
+    Given a remote service that returns 'Digest Authenticated Page Using MD5-sess'
+    And that service is accessed at the path '/digest_auth.html'
+    And that service is protected by MD5-sess Digest Authentication
+    And that service requires the username 'jcash' with the password 'maninblack'
+    When I call HTTParty#get with '/digest_auth.html' and a digest_auth hash:
+       | username | password   |
+       | jcash    | maninblack |
+    Then the return value should match 'Digest Authenticated Page Using MD5-sess'

--- a/features/steps/remote_service_steps.rb
+++ b/features/steps/remote_service_steps.rb
@@ -55,6 +55,10 @@ Given /that service is protected by Digest Authentication/ do
   @handler.extend DigestAuthentication
 end
 
+Given /that service is protected by MD5-sess Digest Authentication/ do
+  @handler.extend DigestAuthenticationUsingMD5Sess
+end
+
 Given /that service requires the username '(.*)' with the password '(.*)'/ do |username, password|
   @handler.username = username
   @handler.password = password

--- a/spec/httparty/net_digest_auth_spec.rb
+++ b/spec/httparty/net_digest_auth_spec.rb
@@ -188,4 +188,43 @@ RSpec.describe Net::HTTPHeader::DigestAuthenticator do
       expect(authorization_header).to include(%(response="#{request_digest}"))
     end
   end
+  
+  context "with algorithm specified" do
+    before do
+      @digest = setup_digest({
+                              'www-authenticate' => 'Digest realm="myhost@testrealm.com", nonce="NONCE", qop="auth", algorithm=MD5'
+                             })
+    end
+    
+    it "should recognise algorithm was specified" do
+      expect( @digest.send :algorithm_present? ).to be(true)
+    end
+    
+    it "should set the algorithm header" do
+      expect(authorization_header).to include('algorithm="MD5"')
+    end
+  end
+
+  context "with md5-sess algorithm specified" do
+    before do
+      @digest = setup_digest({
+                              'www-authenticate' => 'Digest realm="myhost@testrealm.com", nonce="NONCE", qop="auth", algorithm=MD5-sess'
+                             })
+    end
+    
+    it "should recognise algorithm was specified" do
+      expect( @digest.send :algorithm_present? ).to be(true)
+    end
+    
+    it "should set the algorithm header" do
+      expect(authorization_header).to include('algorithm="MD5-sess"')
+    end
+    
+    it "should set response using md5-sess algorithm" do
+      request_digest = "md5(md5(md5(Mufasa:myhost@testrealm.com:Circle Of Life):NONCE:md5(deadbeef)):NONCE:00000001:md5(deadbeef):auth:md5(GET:/dir/index.html))"
+      expect(authorization_header).to include(%(response="#{request_digest}"))
+    end
+    
+  end
+  
 end


### PR DESCRIPTION
Hi,
I've implemented support for the algorithm=MD5-sess header, as specified in RFC2617.

This addresses bug #200 

New tests added, and all tests pass ( had to change the address used from 0.0.0.0 to 127.0.0.1 locally in all cases, though. Don't know why) 

I've also tested against an IIS8.5 server with digest auth enabled.

Let me know if there's anything else required.

Tony