### PR TITLE
Request method is not being preserved on 307 and 308 redirects 

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -282,7 +282,7 @@ module HTTParty
           unless options[:maintain_method_across_redirects] && options[:resend_on_redirect]
             self.http_method = Net::HTTP::Get
           end
-        elsif last_response.code != 307 && last_response.code != 308
+        elsif last_response.code != '307' && last_response.code != '308'
           unless options[:maintain_method_across_redirects]
             self.http_method = Net::HTTP::Get
           end

--- a/spec/support/stub_response.rb
+++ b/spec/support/stub_response.rb
@@ -26,7 +26,8 @@ module HTTParty
       expect(HTTParty::Request).to receive(:new).and_return(http_request)
     end
 
-    def stub_response(body, code = 200)
+    def stub_response(body, code = '200')
+      code = code.to_s
       @request.options[:base_uri] ||= 'http://localhost'
       unless defined?(@http) && @http
         @http = Net::HTTP.new('localhost', 80)
@@ -34,10 +35,10 @@ module HTTParty
       end
 
       # CODE_TO_OBJ currently missing 308
-      if code.to_s == '308'
+      if code == '308'
         response = Net::HTTPRedirection.new("1.1", code, body)
       else
-        response = Net::HTTPResponse::CODE_TO_OBJ[code.to_s].new("1.1", code, body)
+        response = Net::HTTPResponse::CODE_TO_OBJ[code].new("1.1", code, body)
       end
       allow(response).to receive(:body).and_return(body)
 


### PR DESCRIPTION
Tested on master:

```
➜  httparty git:(master) cat redirect.rb
require 'sinatra'

post '/redirect-307' do
  redirect '/target', 307
end

post '/target' do
  'Target'
end
```
```
➜  httparty git:(master) ruby -Ilib -rhttparty -e 'HTTParty.post "http://localhost:4567/redirect-307"'
```
```
➜  httparty git:(master) ruby redirect.rb
Puma 2.11.3 starting...
* Min threads: 0, max threads: 16
* Environment: development
* Listening on tcp://localhost:4567
== Sinatra/1.4.5 has taken the stage on 4567 for development with backup from Puma
127.0.0.1 - - [16/Sep/2015:14:22:02 -0700] "POST /redirect-307 HTTP/1.1" 307 - 0.0048
127.0.0.1 - - [16/Sep/2015:14:22:02 -0700] "GET /target HTTP/1.1" 404 443 0.0017
^C== Sinatra has ended his set (crowd applauds)
```


`Net:HTTTP` status codes should always be handled as strings. `Net::HTTPReponse#new` will pass through whatever you give it as the `code`, although a real `Net::HTTPResponse` status code is always a string.

http://docs.ruby-lang.org/en/2.0.0/Net/HTTPResponse.html#attribute-i-code.

On this branch:

```
➜  httparty git:(307-308-redirect-status-codes) ruby redirect.rbPuma 2.11.3 starting...
* Min threads: 0, max threads: 16
* Environment: development
* Listening on tcp://localhost:4567
== Sinatra/1.4.5 has taken the stage on 4567 for development with backup from Puma
127.0.0.1 - - [16/Sep/2015:14:24:36 -0700] "POST /redirect-307 HTTP/1.1" 307 - 0.0037
127.0.0.1 - - [16/Sep/2015:14:24:36 -0700] "POST /target HTTP/1.1" 200 6 0.0013
^C== Sinatra has ended his set (crowd applauds)
```
```
➜  httparty git:(307-308-redirect-status-codes) ruby -Ilib -rhttparty -e 'HTTParty.post "http://localhost:4567/redirect-307"'
```