### PR TITLE
Stop trying to deflate responses that redirect.

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -298,6 +298,8 @@ module HTTParty
 
     # Inspired by Ruby 1.9
     def handle_deflation
+      return if response_redirects?
+
       case last_response["content-encoding"]
       when "gzip", "x-gzip"
         body_io = StringIO.new(last_response.body)

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -1016,6 +1016,20 @@ RSpec.describe HTTParty::Request do
         expect(@request.last_response).to receive(:delete).with('content-encoding')
         @request.send(:handle_deflation)
       end
+
+      it "should not inflate a redirected response with content-encoding: gzip" do
+        allow(@last_response).to receive(:[]).with("content-encoding").and_return("gzip")
+        allow(@request).to receive(:last_response).and_return(@last_response)
+        allow(@request).to receive(:response_redirects?).and_return(true)
+        @request.send(:handle_deflation)
+      end
+
+      it "should not inflate a redirected response with content-encoding: deflate" do
+        allow(@last_response).to receive(:[]).with("content-encoding").and_return("deflate")
+        allow(@request).to receive(:last_response).and_return(@last_response)
+        allow(@request).to receive(:response_redirects?).and_return(true)
+        @request.send(:handle_deflation)
+      end
     end
   end
 


### PR DESCRIPTION
Some servers (including YouTube) will send a redirect response with a
Content-Encoding header, but no body.  Since inflating an empty body
raises an exception, we should minimally work around this problem for
non-terminal redirect responses.

Note that this will still attempt to inflate a redirected response body
if HTTParty is not configured to follow redirects (which will raise
exceptions if the body is empty), and this does nothing to protect
against otherwise empty responses with a compressed Content-Encoding
(which may indicate a mis-configured server).