### PR TITLE
Remove high-byte emoji from post-install message

### DIFF
--- a/httparty.gemspec
+++ b/httparty.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'multi_xml', ">= 0.5.2"
 
   # If this line is removed, all hard partying will cease.
-  s.post_install_message = "When you HTTParty, you must party hard! 🎉"
+  s.post_install_message = "When you HTTParty, you must party hard!"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Since @jnunemaker will never remove the message (even though he never sees it because he runs with `--quiet`), at least make it so that the regular output is ASCII.