### PR TITLE
fix cookie bug in tripit-sign-in example

### DIFF
--- a/examples/tripit_sign_in.rb
+++ b/examples/tripit_sign_in.rb
@@ -3,29 +3,40 @@ require File.join(dir, 'httparty')
 
 class TripIt
   include HTTParty
-  base_uri 'http://www.tripit.com'
+  base_uri 'https://www.tripit.com'
   debug_output
 
   def initialize(email, password)
     @email = email
-    response = self.class.get('/account/login')
-    response = self.class.post(
+    get_response = self.class.get('/account/login')
+    get_response_cookie = parse_cookie(get_response.headers['Set-Cookie'])
+
+    post_response = self.class.post(
       '/account/login',
       body: {
         login_email_address: email,
         login_password: password
       },
-      headers: {'Cookie' => response.headers['Set-Cookie']}
+      headers: {'Cookie' => get_response_cookie.to_cookie_string }
     )
-    @cookie = response.request.options[:headers]['Cookie']
+
+    @cookie = parse_cookie(post_response.headers['Set-Cookie'])
   end
 
   def account_settings
-    self.class.get('/account/edit', headers: {'Cookie' => @cookie})
+    self.class.get('/account/edit', headers: {'Cookie' => @cookie.to_cookie_string})
   end
 
   def logged_in?
     account_settings.include? "You're logged in as #{@email}"
+  end
+
+  private
+
+  def parse_cookie(resp)
+    cookie_hash = CookieHash.new
+    resp.get_fields('Set-Cookie').each { |c| cookie_hash.add_cookies(c) }
+    cookie_hash
   end
 end
 


### PR DESCRIPTION
Old example is putting `response.headers['Set-Cookie']` into `request.options[:headers]['Cookie']` directly.

The `Set-Cookie` which responsed from server is looks like
```
Set-Cookie: PHPSESSID=bo2h26ffuqvs91k1dig5g77694; path=/; HttpOnly, _csrf=5182ab96214158ac793b299fc8cc8164689cc0ccfff119152c22817fcb03eccca%3A2%3A%7Bi%3A0%3Bs%3A5%3A%22_csrf%22%3Bi%3A1%3Bs%3A32%3A%22QGX1SwJAwz_9GpUUuETOnTlIUgzf4S_c%22%3B%7D; path=/; httponly
```

But `Cookie` which we will sent to server is looks like
```
Cookie: PHPSESSID=bo2h26ffuqvs91k1dig5g77694; _csrf=5182ab96214158ac793b299fc8cc8164689cc0ccfff119152c22817fcb03eccca%3A2%3A%7Bi%3A0%3Bs%3A5%3A%22_csrf%22%3Bi%3A1%3Bs%3A32%3A%22QGX1SwJAwz_9GpUUuETOnTlIUgzf4S_c%22%3B%7D
```
The value is not equal, and some HTTP servers ( which I have tried Apache ) cannot recognize it.