### PR TITLE
Solves #266 - Honors the verify option to avoid overrides

### DIFF
--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -158,7 +158,7 @@ module HTTParty
         if options[:pem]
           http.cert = OpenSSL::X509::Certificate.new(options[:pem])
           http.key = OpenSSL::PKey::RSA.new(options[:pem], options[:pem_password])
-          http.verify_mode = options[:verify_peer] == false ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
+          http.verify_mode = options[:verify] == false ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
         end
 
         # PKCS12 client certificate authentication
@@ -166,7 +166,7 @@ module HTTParty
           p12 = OpenSSL::PKCS12.new(options[:p12], options[:p12_password])
           http.cert = p12.certificate
           http.key = p12.key
-          http.verify_mode = options[:verify_peer] == false ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
+          http.verify_mode = options[:verify] == false ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
         end
 
         # SSL certificate authority file and/or directory

--- a/spec/httparty/connection_adapter_spec.rb
+++ b/spec/httparty/connection_adapter_spec.rb
@@ -373,7 +373,7 @@ RSpec.describe HTTParty::ConnectionAdapter do
           end
 
           context "when options include verify_peer=false" do
-            let(:options) { {pem: pem, pem_password: "password", verify_peer: false} }
+            let(:options) { {pem: pem, pem_password: "password", verify: false} }
 
             it "should not verify the certificate" do
               expect(subject.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
@@ -424,7 +424,7 @@ RSpec.describe HTTParty::ConnectionAdapter do
           end
 
           context "when options include verify_peer=false" do
-            let(:options) { {p12: p12, p12_password: "password", verify_peer: false} }
+            let(:options) { {p12: p12, p12_password: "password", verify: false} }
 
             it "should not verify the certificate" do
               expect(subject.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)

--- a/spec/httparty/connection_adapter_spec.rb
+++ b/spec/httparty/connection_adapter_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe HTTParty::ConnectionAdapter do
     it "sets the options" do
       options = {foo: :bar}
       adapter = HTTParty::ConnectionAdapter.new(uri, options)
-      expect(adapter.options).to be options
+      expect(adapter.options.keys).to include(:verify, :verify_peer, :foo)
     end
   end
 
@@ -372,8 +372,15 @@ RSpec.describe HTTParty::ConnectionAdapter do
             expect(subject.verify_mode).to eq(OpenSSL::SSL::VERIFY_PEER)
           end
 
-          context "when options include verify_peer=false" do
+          context "when options include verify=false" do
             let(:options) { {pem: pem, pem_password: "password", verify: false} }
+
+            it "should not verify the certificate" do
+              expect(subject.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
+            end
+          end
+          context "when options include verify_peer=false" do
+            let(:options) { {pem: pem, pem_password: "password", verify_peer: false} }
 
             it "should not verify the certificate" do
               expect(subject.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
@@ -423,8 +430,15 @@ RSpec.describe HTTParty::ConnectionAdapter do
             expect(subject.verify_mode).to eq(OpenSSL::SSL::VERIFY_PEER)
           end
 
-          context "when options include verify_peer=false" do
+          context "when options include verify=false" do
             let(:options) { {p12: p12, p12_password: "password", verify: false} }
+
+            it "should not verify the certificate" do
+              expect(subject.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
+            end
+          end
+          context "when options include verify_peer=false" do
+            let(:options) { {p12: p12, p12_password: "password", verify_peer: false} }
 
             it "should not verify the certificate" do
               expect(subject.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)


### PR DESCRIPTION
####What does this PR do?

* Honors the verify option to prevent `http.verify_mode` when using `pem` or `pk12` options