### PR TITLE
Implement is_a? and kind_of? in httparty response

### DIFF
--- a/features/steps/httparty_response_steps.rb
+++ b/features/steps/httparty_response_steps.rb
@@ -11,8 +11,8 @@ def constantize(camel_cased_word)
   constant
 end
 
-Then /it should return an? (\w+)$/ do |class_string|
-  expect(@response_from_httparty).to be_a(class_string.class)
+Then /it should return an? ([\w\:]+)$/ do |class_string|
+  expect(@response_from_httparty.parsed_response).to be_a(Object.const_get(class_string))
 end
 
 Then /the return value should match '(.*)'/ do |expected_text|
@@ -20,7 +20,7 @@ Then /the return value should match '(.*)'/ do |expected_text|
 end
 
 Then /it should return a Hash equaling:/ do |hash_table|
-  expect(@response_from_httparty).to be_a(Hash)
+  expect(@response_from_httparty.parsed_response).to be_a(Hash)
   expect(@response_from_httparty.keys.length).to eq(hash_table.rows.length)
   hash_table.hashes.each do |pair|
     key, value = pair["key"], pair["value"]
@@ -30,7 +30,7 @@ Then /it should return a Hash equaling:/ do |hash_table|
 end
 
 Then /it should return an Array equaling:/ do |array|
-  expect(@response_from_httparty).to be_a(Array)
+  expect(@response_from_httparty.parsed_response).to be_a(Array)
   expect(@response_from_httparty.parsed_response).to eq(array.raw)
 end
 

--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -27,6 +27,12 @@ module HTTParty
       Response
     end
 
+    def is_a?(klass)
+      self.class == klass || self.class < klass
+    end
+
+    alias_method :kind_of?, :is_a?
+
     def code
       response.code.to_i
     end

--- a/spec/httparty/response_spec.rb
+++ b/spec/httparty/response_spec.rb
@@ -114,6 +114,24 @@ RSpec.describe HTTParty::Response do
     end
   end
 
+  describe "#is_a?" do
+    subject { HTTParty::Response.new(@request_object, @response_object, @parsed_response) }
+
+    it { is_expected.to respond_to(:is_a?).with(1).arguments }
+    it { expect(subject.is_a?(HTTParty::Response)).to be_truthy }
+    it { expect(subject.is_a?(BasicObject)).to be_truthy }
+    it { expect(subject.is_a?(Object)).to be_falsey }
+  end
+
+  describe "#kind_of?" do
+    subject { HTTParty::Response.new(@request_object, @response_object, @parsed_response) }
+
+    it { is_expected.to respond_to(:kind_of?).with(1).arguments }
+    it { expect(subject.kind_of?(HTTParty::Response)).to be_truthy }
+    it { expect(subject.kind_of?(BasicObject)).to be_truthy }
+    it { expect(subject.kind_of?(Object)).to be_falsey }
+  end
+
   describe "semantic methods for response codes" do
     def response_mock(klass)
       response = klass.new('', '', '')


### PR DESCRIPTION
Fixes a step definition that appeared to check response type against a user defined class but actually always checked against String.

Adds support for `is_a?` and `kind_of?` to the `HTTParty::Response` object and uses the fixed step definition to test the implementation.

Previously these were delegated to the `parsed_response` object, which led to unpredictable behaviour; such as:

```ruby
response.class == HTTParty::Response #true

response.is_a?(HTTParty::Response) # false
```