### PR TITLE
Fix deprecations, and add additional steps that we're using.

### DIFF
--- a/features/steps/httparty_response_steps.rb
+++ b/features/steps/httparty_response_steps.rb
@@ -50,3 +50,7 @@ Then /it should raise (?:an|a) ([\w:]+) exception/ do |exception|
   expect(@exception_from_httparty).to_not be_nil
   expect(@exception_from_httparty).to be_a constantize(exception)
 end
+
+Then /it should not raise (?:an|a) ([\w:]+) exception/ do |exception|
+  expect(@exception_from_httparty).to be_nil
+end

--- a/features/steps/remote_service_steps.rb
+++ b/features/steps/remote_service_steps.rb
@@ -17,9 +17,11 @@ Given /that service is accessed at the path '(.*)'/ do |path|
   @server.register(path, @handler)
 end
 
-Given /^that service takes (\d+) seconds to generate a response$/ do |time|
-  @server_response_time = time.to_i
-  @handler.preprocessor = proc { sleep time.to_i }
+Given /^that service takes (\d+) (.*) to generate a response$/ do |time, unit|
+  time = time.to_i
+  time *= 60 if unit =~ /minute/
+  @server_response_time = time
+  @handler.preprocessor = proc { sleep time }
 end
 
 Given /^a remote deflate service$/ do
@@ -66,7 +68,7 @@ end
 
 # customize aruba cucumber step
 Then /^the output should contain '(.*)'$/ do |expected|
-  assert_partial_output(expected, all_output)
+  expect(all_commands.map(&:output).join("\n")).to match_output_string(expected)
 end
 
 Given /a restricted page at '(.*)'/ do |url|

--- a/spec/httparty/cookie_hash_spec.rb
+++ b/spec/httparty/cookie_hash_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe HTTParty::CookieHash do
       it "should error" do
         expect {
           @cookie_hash.add_cookies([])
-        }.to raise_error
+        }.to raise_error(RuntimeError)
       end
     end
   end


### PR DESCRIPTION
This pull request does two things:

- Fix deprecations that are raised by Aruba. Future versions of Aruba will certainly break a handful of tests.
- Extend a few of the Cucumber steps to be more flexible.
  - I have a few other tests I'm writing for extremely long timeouts, which I'm not committing. I don't want to include them and mark them as pending when they're not pending. And they add a huge amount of time to test runs, because they're testing huge amounts of time.

No new features in this pull request, just some cleanup. Everything passes on Ruby 2.2.3.