### PR TITLE
Version 1.0.0

### DIFF
--- a/lib/httparty/version.rb
+++ b/lib/httparty/version.rb
@@ -1,3 +1,3 @@
 module HTTParty
-  VERSION = "0.13.7"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
This library is 7 1/2 years old – might it be time to consider it mature? :)

This is not intended as a dig but as a practical concern: I noticed the pre-1.0 version when updating gems and reflected on the fact that if it was post 1.0 and used semantic versioning, I could have more easily judged the impact of the upgrade.

I know the contribution guidelines say don't mess with the version, but it's hard to avoid in this case :D 
