### PR TITLE
Raise on some HTTP status codes

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -72,6 +72,16 @@ module HTTParty
       default_options[:log_format] = format
     end
 
+    # Raises HTTParty::ResponseError if response's code matches this statuses
+    #
+    #   class Foo
+    #     include HTTParty
+    #     raise_on [404, 500]
+    #   end
+    def raise_on(codes = [])
+      default_options[:raise_on] = *codes
+    end
+
     # Allows setting http proxy information to be used
     #
     #   class Foo

--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -17,6 +17,8 @@ module HTTParty
         logger = ::HTTParty::Logger.build(request.options[:logger], request.options[:log_level], request.options[:log_format])
         logger.format(request, self)
       end
+
+      throw_exception
     end
 
     def parsed_response
@@ -75,6 +77,12 @@ module HTTParty
         response.send(name, *args, &block)
       else
         super
+      end
+    end
+
+    def throw_exception
+      if @request.options[:raise_on] && @request.options[:raise_on].include?(code)
+        ::Kernel.raise ::HTTParty::ResponseError.new(@response), "Code #{code} - #{body}"
       end
     end
   end

--- a/spec/httparty/response_spec.rb
+++ b/spec/httparty/response_spec.rb
@@ -43,6 +43,33 @@ RSpec.describe HTTParty::Response do
     it "should set code as a Fixnum" do
       expect(@response.code).to be_an_instance_of(Fixnum)
     end
+
+    context 'when raise_on is supplied' do
+      let(:request) { HTTParty::Request.new(Net::HTTP::Get, '/', raise_on: [404]) }
+
+      context "and response's status code is in range" do
+        let(:body)     { 'Not Found' }
+        let(:response) { Net::HTTPNotFound.new('1.1', 404, body) }
+
+        before do
+          allow(response).to receive(:body).and_return(body)
+        end
+
+        subject { described_class.new(request, response, @parsed_response) }
+
+        it 'throws exception' do
+          expect{ subject }.to raise_error(HTTParty::ResponseError, "Code 404 - #{body}")
+        end
+      end
+
+      context "and response's status code is not in range" do
+        subject { described_class.new(request, @response_object, @parsed_response) }
+
+        it 'does not throw exception' do
+          expect{ subject }.not_to raise_error(HTTParty::ResponseError)
+        end
+      end
+    end
   end
 
   it "returns response headers" do

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -525,6 +525,22 @@ RSpec.describe HTTParty do
     end
   end
 
+  describe ".raise_on" do
+    context 'when parameters is an array' do
+      it 'sets raise_on option' do
+        @klass.raise_on [500, 404]
+        expect(@klass.default_options[:raise_on]).to contain_exactly(404, 500)
+      end
+    end
+
+    context 'when parameters is a fixnum' do
+      it 'sets raise_on option' do
+        @klass.raise_on 404
+        expect(@klass.default_options[:raise_on]).to contain_exactly(404)
+      end
+    end
+  end
+
   describe "with explicit override of automatic redirect handling" do
     before do
       @request = HTTParty::Request.new(Net::HTTP::Get, 'http://api.foo.com/v1', format: :xml, no_follow: true)


### PR DESCRIPTION
#### What?

Implements the proposal #454   

#### Why?

When you use httparty in many different projects it starts to become tedious to add a verification on every request. To accomplish this, you have to do something like this: 

```ruby
module Api
  class Base
    include HTTParty

    def get(path, options = {})
      raises_unless_success { self.class.get path, options }
    end

    private

     def raises_unless_success
      httparty = yield
      fail HTTParty::Error, "Code #{httparty.code} - #{httparty.body}" unless
        httparty.response.is_a?(Net::HTTPSuccess)
      httparty
    end

  end
end
```

I believe this is not a straight solution.

### My idea

```ruby
module Api
  class Base
    include HTTParty
    raise_on (400..599).to_a

    def get(path, options = {})
      self.class.get path, options
    end
  end
end
```