### PR TITLE
Allow nil http_proxyaddr to pass through to Net::HTTP

### DIFF
--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -76,7 +76,7 @@ module HTTParty
     def connection
       host = clean_host(uri.host)
       port = uri.port || (uri.scheme == 'https' ? 443 : 80)
-      if options[:http_proxyaddr]
+      if options.has_key?(:http_proxyaddr)
         http = Net::HTTP.new(host, port, options[:http_proxyaddr], options[:http_proxyport], options[:http_proxyuser], options[:http_proxypass])
       else
         http = Net::HTTP.new(host, port)

--- a/spec/httparty/connection_adapter_spec.rb
+++ b/spec/httparty/connection_adapter_spec.rb
@@ -325,6 +325,19 @@ RSpec.describe HTTParty::ConnectionAdapter do
         end
       end
 
+      context 'when providing nil as proxy address' do
+        let(:uri) { URI 'http://noproxytest.com' }
+        let(:options) { {http_proxyaddr: nil} }
+
+        it { is_expected.not_to be_a_proxy }
+
+        it "does pass nil proxy parameters to the connection, this forces to not use a proxy" do
+          http = Net::HTTP.new("noproxytest.com")
+          expect(Net::HTTP).to receive(:new).once.with("noproxytest.com", 80, nil, nil, nil, nil).and_return(http)
+          adapter.connection
+        end
+      end
+
       context 'when not providing a proxy address' do
         let(:uri) { URI 'http://proxytest.com' }
 


### PR DESCRIPTION
This is useful when a proxy is used by default but you do not want to use it for some requests