### PR TITLE
Use reject instead of delete_if to prevent mutation

### DIFF
--- a/lib/httparty/cookie_hash.rb
+++ b/lib/httparty/cookie_hash.rb
@@ -16,6 +16,6 @@ class HTTParty::CookieHash < Hash #:nodoc:
   end
 
   def to_cookie_string
-    delete_if { |k, v| CLIENT_COOKIES.include?(k.to_s.downcase) }.collect { |k, v| "#{k}=#{v}" }.join("; ")
+    reject { |k, v| CLIENT_COOKIES.include?(k.to_s.downcase) }.collect { |k, v| "#{k}=#{v}" }.join("; ")
   end
 end

--- a/spec/httparty/cookie_hash_spec.rb
+++ b/spec/httparty/cookie_hash_spec.rb
@@ -79,5 +79,22 @@ RSpec.describe HTTParty::CookieHash do
       @s = @cookie_hash.to_cookie_string
       expect(@s).not_to match(/Path=\//)
     end
+
+    it "should not mutate the hash" do
+      original_hash = {
+        "session" => "91e25e8b-6e32-418d-c72f-2d18adf041cd",
+        "Max-Age" => "15552000",
+        "cart" => "91e25e8b-6e32-418d-c72f-2d18adf041cd",
+        "httponly" => nil,
+        "Path" => "/",
+        "secure" => nil,
+      }
+
+      cookie_hash = HTTParty::CookieHash[original_hash]
+
+      cookie_hash.to_cookie_string
+
+      expect(cookie_hash).to eq(original_hash)
+    end
   end
 end


### PR DESCRIPTION
Solves https://github.com/jnunemaker/httparty/issues/459. `Hash#reject` returns a new hash instead of mutating. http://ruby-doc.org/core-2.2.0/Hash.html#method-i-reject