### PR TITLE
Remove json gem

### DIFF
--- a/httparty.gemspec
+++ b/httparty.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version     = '>= 1.9.3'
 
-  s.add_dependency 'json',      "~> 1.8"
   s.add_dependency 'multi_xml', ">= 0.5.2"
 
   # If this line is removed, all hard partying will cease.


### PR DESCRIPTION
JSON support is in Ruby since 1.9 so there is no need to have json gem as a dependency.

Inspired by this Rack’s PR https://github.com/rack/rack/pull/1011