### PR TITLE
Implemented support for MKCOL method

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -538,6 +538,11 @@ module HTTParty
       perform_request Net::HTTP::Options, path, options, &block
     end
 
+    # Perform a MKCOL request to a path
+    def mkcol(path, options = {}, &block)
+      perform_request Net::HTTP::Mkcol, path, options, &block
+    end
+
     attr_reader :default_options
 
     private

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -9,7 +9,8 @@ module HTTParty
       Net::HTTP::Head,
       Net::HTTP::Options,
       Net::HTTP::Move,
-      Net::HTTP::Copy
+      Net::HTTP::Copy,
+      Net::HTTP::Mkcol
     ]
 
     SupportedURISchemes  = ['http', 'https', 'webcal', nil]

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -10,7 +10,7 @@ module HTTParty
       Net::HTTP::Options,
       Net::HTTP::Move,
       Net::HTTP::Copy,
-      Net::HTTP::Mkcol
+      Net::HTTP::Mkcol,
     ]
 
     SupportedURISchemes  = ['http', 'https', 'webcal', nil]

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -594,6 +594,11 @@ RSpec.describe HTTParty::Request do
           expect(@request.perform.parsed_response).to eq({"hash" => {"foo" => "bar"}})
         end
 
+        it "should be handled by MKCOL transparently" do
+          @request.http_method = Net::HTTP::Mkcol
+          expect(@request.perform.parsed_response).to eq({"hash" => {"foo" => "bar"}})
+        end
+
         it "should keep track of cookies between redirects" do
           @redirect['Set-Cookie'] = 'foo=bar; name=value; HTTPOnly'
           @request.perform
@@ -712,6 +717,11 @@ RSpec.describe HTTParty::Request do
 
       it "should be handled by OPTIONS transparently" do
         @request.http_method = Net::HTTP::Options
+        expect(@request.perform.parsed_response).to eq({"hash" => {"foo" => "bar"}})
+      end
+
+      it "should be handled by MKCOL transparently" do
+        @request.http_method = Net::HTTP::Mkcol
         expect(@request.perform.parsed_response).to eq({"hash" => {"foo" => "bar"}})
       end
 
@@ -848,6 +858,11 @@ RSpec.describe HTTParty::Request do
       expect(@request.perform.code).to eq(304)
     end
 
+    it "should report 304 with a MKCOL request" do
+      @request.http_method = Net::HTTP::Mkcol
+      expect(@request.perform.code).to eq(304)
+    end
+
     it 'should not log the redirection' do
       logger_double = double
       expect(logger_double).to receive(:info).once
@@ -911,6 +926,11 @@ RSpec.describe HTTParty::Request do
 
         it "should be handled by OPTIONS transparently" do
           @request.http_method = Net::HTTP::Options
+          expect(@request.perform.parsed_response).to eq({"hash" => {"foo" => "bar"}})
+        end
+
+        it "should be handled by MKCOL transparently" do
+          @request.http_method = Net::HTTP::Mkcol
           expect(@request.perform.parsed_response).to eq({"hash" => {"foo" => "bar"}})
         end
 

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -602,6 +602,12 @@ RSpec.describe HTTParty do
         @klass.options('/foo', no_follow: true)
       end.to raise_error(HTTParty::RedirectionTooDeep) {|e| expect(e.response.body).to eq('first redirect')}
     end
+
+    it "should fail with redirected MKCOL" do
+      expect do
+        @klass.mkcol('/foo', no_follow: true)
+      end.to raise_error(HTTParty::RedirectionTooDeep) {|e| expect(e.response.body).to eq('first redirect')}
+    end
   end
 
   describe "head requests should follow redirects requesting HEAD only" do


### PR DESCRIPTION
`MKCOL` - part of the [HTTP Extensions for Distributed Authoring](http://www.webdav.org/specs/rfc2518.html) (also known as WebDAV) - allow creation of a new collection resource at the location specified.

By extending with the `MKCOL` method, will cover (most) basic WebDAV implementation and make `httparty` more generic and increase the fun :smile: