### PR TITLE
Fix base uri options not normalized

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -94,7 +94,7 @@ module HTTParty
         base_uri += ":#{@last_uri.port}" if @last_uri.port != 80
         base_uri
       else
-        options[:base_uri]
+        options[:base_uri] && HTTParty.normalize_base_uri(options[:base_uri])
       end
     end
 

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -168,6 +168,14 @@ RSpec.describe HTTParty::Request do
       request.send(:setup_raw_request)
       expect(request.instance_variable_get(:@raw_request).body_stream).to eq(stream)
     end
+
+    it 'should normalize base uri when specified as request option' do
+      FakeWeb.register_uri(:get, 'http://foo.com/resource', :body => 'Bar')
+      response = HTTParty.get('/resource', {
+        base_uri: 'foo.com'
+      })
+      expect(response.code).to eq(200)
+    end
   end
 
   describe "#uri" do


### PR DESCRIPTION
Calling `HTTParty::ClassMethods.base_uri` or passing `base_uri` to a request method do not behave the same way. The class method call normalize the uri, while passing options does not. 

This will throw an error due to the url no being valid (it lacks the scheme in the url)

```ruby
HTTParty.get('/resource', {
  base_uri: 'foo.com',
  body: {}
})
```

But this will works fine,[`HTTParty.normalize_base_uri`](https://github.com/jnunemaker/httparty/blob/master/lib/httparty.rb#L107) takes care of adding the scheme  
```ruby
class Myclass
  include HTTParty
  base_uri 'foo.com'

  def get_it
    get('/resource', {
      body: {}
    })
  end
end
```