### PR TITLE
Update post method documentation examples

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -496,7 +496,7 @@ module HTTParty
     #   Foo.post('http://foo.com/resources', body: {bar: 'baz'})
     #
     #   # Simple post with full url using :query option,
-    #   # which gets set as form data on the request.
+    #   # which appends the parameters to the URI.
     #   Foo.post('http://foo.com/resources', query: {bar: 'baz'})
     def post(path, options = {}, &block)
       perform_request Net::HTTP::Post, path, options, &block


### PR DESCRIPTION
This behavior appears to have changed with 49956a707e31a231a6670027222a213280d65d22, but the documentation was not updated at that time. Apologies in advance if I've misunderstood something.