### PR TITLE
Allow empty array to be used as a params in get requests.

### DIFF
--- a/lib/httparty/hash_conversions.rb
+++ b/lib/httparty/hash_conversions.rb
@@ -26,7 +26,11 @@ module HTTParty
       stack = []
 
       if value.respond_to?(:to_ary)
-        param << value.to_ary.map { |element| normalize_param("#{key}[]", element) }.join
+        param << if value.empty?
+                   "#{key}[]=&"
+                 else
+                   value.to_ary.map { |element| normalize_param("#{key}[]", element) }.join
+                 end
       elsif value.respond_to?(:to_hash)
         stack << [key, value.to_hash]
       else

--- a/spec/httparty/hash_conversions_spec.rb
+++ b/spec/httparty/hash_conversions_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe HTTParty::HashConversions do
       end
     end
 
+    context "value is an empty array" do
+      it "creates a params string" do
+        expect(
+          HTTParty::HashConversions.normalize_param(:people, [])
+        ).to eq("people[]=&")
+      end
+    end
+
     context "value is hash" do
       it "creates a params string" do
         expect(

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -56,6 +56,24 @@ RSpec.describe HTTParty::Request do
       expect(request.connection_adapter).to eq(my_adapter)
     end
 
+    context "when using a query string" do
+      context "and it has an empty array" do
+        it "sets correct query string" do
+          request = HTTParty::Request.new(Net::HTTP::Get, 'http://google.com', query: { fake_array: [] })
+
+          expect(request.uri).to eq(URI.parse("http://google.com/?fake_array[]="))
+        end
+      end
+
+      context "when sending an array with only one element" do
+        it "sets correct query" do
+          request = HTTParty::Request.new(Net::HTTP::Get, 'http://google.com', query: { fake_array: [1] })
+
+          expect(request.uri).to eq(URI.parse("http://google.com/?fake_array[]=1"))
+        end
+      end
+    end
+
     context "when basic authentication credentials provided in uri" do
       context "when basic auth options wasn't set explicitly" do
         it "sets basic auth from uri" do
@@ -221,10 +239,10 @@ RSpec.describe HTTParty::Request do
       end
 
       it "respects the query string normalization proc" do
-        empty_proc = lambda {|qs| ""}
+        empty_proc = lambda {|qs| "I"}
         @request.options[:query_string_normalizer] = empty_proc
         @request.options[:query] = {foo: :bar}
-        expect(CGI.unescape(@request.uri.query)).to eq("")
+        expect(CGI.unescape(@request.uri.query)).to eq("I")
       end
 
       it "does not append an ampersand when queries are embedded in paths" do


### PR DESCRIPTION
Fixes #469 

Now we have:

```
>> res = HTTParty.get('http://github.com', query: {fake_array: []})
# […]
>> res.request.last_uri.to_s
=> "https://github.com/?fake_array[]="
```

And:

```
>> res = HTTParty.get('http://github.com', query: {fake_array: [1]})
# […]
>> res.request.last_uri.to_s
=> "https://github.com/?fake_array[]=1"
```

Besides this fix I'd like to know what happens if you have something like this: `HTTParty::Request.new(Net::HTTP::Get, 'http://google.com', query: { fake_array: [""] })`