### PR TITLE
Handle duplicate location headers

### DIFF
--- a/lib/httparty/exceptions.rb
+++ b/lib/httparty/exceptions.rb
@@ -26,4 +26,7 @@ module HTTParty
   # Exception that is raised when request has redirected too many times.
   # Calling {#response} returns the Net:HTTP response object.
   class RedirectionTooDeep < ResponseError; end
+
+  # Exception that is raised when request redirects and location header is present more than once
+  class DuplicateLocationHeader < ResponseError; end
 end

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -315,9 +315,17 @@ module HTTParty
     end
 
     def handle_host_redirection
+      check_duplicate_location_header
       redirect_path = options[:uri_adapter].parse last_response['location']
       return if redirect_path.relative? || path.host == redirect_path.host
       @changed_hosts = true
+    end
+
+    def check_duplicate_location_header
+      location = last_response.get_fields('location')
+      if location.is_a?(Array) && location.count > 1
+        raise DuplicateLocationHeader.new(last_response)
+      end
     end
 
     def send_authorization_header?

--- a/spec/httparty/exception_spec.rb
+++ b/spec/httparty/exception_spec.rb
@@ -35,4 +35,11 @@ RSpec.describe HTTParty::Error do
       it { is_expected.to include(HTTParty::ResponseError) }
     end
   end
+
+  describe HTTParty::DuplicateLocationHeader do
+    describe '#ancestors' do
+      subject { super().ancestors }
+      it { is_expected.to include(HTTParty::ResponseError) }
+    end
+  end
 end

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -505,6 +505,12 @@ RSpec.describe HTTParty::Request do
           expect(response.parsed_response).to eq({"hash" => {"foo" => "bar"}})
         end
 
+        it "raises an error if redirect has duplicate location header" do
+          @request = HTTParty::Request.new(Net::HTTP::Get, 'http://test.com/redirect', format: :xml)
+          FakeWeb.register_uri(:get, "http://test.com/redirect", status: [300, "REDIRECT"], location: ["http://api.foo.com/v2","http://api.foo.com/v2"])
+          expect {@request.perform}.to raise_error(HTTParty::DuplicateLocationHeader)
+        end
+
         it "returns the HTTParty::Response when the 300 does not contain a location header" do
           stub_response '', 300
           expect(HTTParty::Response).to be === @request.perform


### PR DESCRIPTION
This handles duplicate location headers for #478 