### PR TITLE
Add status predicate methods to Response#respond_to?

### DIFF
--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -49,11 +49,17 @@ module HTTParty
       %(#<#{self.class}:0x#{inspect_id} parsed_response=#{parsed_response.inspect}, @response=#{response.inspect}, @headers=#{headers.inspect}>)
     end
 
+    RESPOND_TO_METHODS = [:request, :response, :parsed_response, :body, :headers]
+
     CODES_TO_OBJ = ::Net::HTTPResponse::CODE_CLASS_TO_OBJ.merge ::Net::HTTPResponse::CODE_TO_OBJ
 
     CODES_TO_OBJ.each do |response_code, klass|
       name = klass.name.sub("Net::HTTP", '')
-      define_method("#{underscore(name)}?") do
+      name = "#{underscore(name)}?".to_sym
+
+      RESPOND_TO_METHODS << name
+
+      define_method(name) do
         klass === response
       end
     end
@@ -64,7 +70,7 @@ module HTTParty
     end
 
     def respond_to?(name, include_all = false)
-      return true if [:request, :response, :parsed_response, :body, :headers].include?(name)
+      return true if RESPOND_TO_METHODS.include?(name)
       parsed_response.respond_to?(name, include_all) || response.respond_to?(name, include_all)
     end
 

--- a/spec/httparty/response_spec.rb
+++ b/spec/httparty/response_spec.rb
@@ -107,6 +107,11 @@ RSpec.describe HTTParty::Response do
     expect(response.respond_to?(:parsed_response)).to be_truthy
   end
 
+  it "responds to predicates" do
+    response = HTTParty::Response.new(@request_object, @response_object, @parsed_response)
+    expect(response.respond_to?(:success?)).to be_truthy
+  end
+
   it "responds to anything parsed_response responds to" do
     response = HTTParty::Response.new(@request_object, @response_object, @parsed_response)
     expect(response.respond_to?(:[])).to be_truthy


### PR DESCRIPTION
Expands the existing `respond_to?` first-party method list to include the HTTP status predicates. Useful for things like RSpec, which check `respond_to?` when using predicate matchers - beyond that it makes for a more consistent and predictable object (If I can call it, it should `respond_to?`).

Because `Response` inherits from `BasicObject` we miss out on quite a few of these pre-made tools from `Object`, though it looked like moving away from `BasicObject` was a bigger task and would require a bit more debate. I figured this was the simplest change to make.

I have not checked for other methods that could be added to `RESPOND_TO_METHODS`, my concern was with the predicate methods.
