### PR TITLE
Require ERB where it's used

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -6,7 +6,6 @@ require 'zlib'
 require 'multi_xml'
 require 'json'
 require 'csv'
-require 'erb'
 
 require 'httparty/module_inheritable_attributes'
 require 'httparty/cookie_hash'

--- a/lib/httparty/hash_conversions.rb
+++ b/lib/httparty/hash_conversions.rb
@@ -1,3 +1,5 @@
+require 'erb'
+
 module HTTParty
   module HashConversions
     # @return <String> This hash as a query string

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -1,3 +1,5 @@
+require 'erb'
+
 module HTTParty
   class Request #:nodoc:
     SupportedHTTPMethods = [


### PR DESCRIPTION
HTTParty users that only require parts of it, e.g. `HashConversions` via `require 'httparty/hash_conversions'`, will see `uninitialized constant HTTParty::HashConversions::ERB` if their code does not itself `require 'erb'`. this is because ERB is only properly required when HTTParty is required with `require 'httparty'`. this PR allows users to use the parts of HTTParty that require ERB without having to `require 'erb'` in their code.