### PR TITLE
Fixing Docs link in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ httparty "https://api.stackexchange.com/2.2/questions?site=stackoverflow"
 
 ## Help and Docs
 
-* [Docs](docs/)
+* [Docs](https://github.com/jnunemaker/httparty/tree/master/docs)
 * https://groups.google.com/forum/#!forum/httparty-gem
 * http://rdoc.info/projects/jnunemaker/httparty
 * http://stackoverflow.com/questions/tagged/httparty


### PR DESCRIPTION
Clicking on `Docs` link in the README file is currently giving a 404.