### PR TITLE
Path options for TLS cert added

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -98,3 +98,13 @@ class Client
 	end
 end
 ```
+
+### Using with `gitlab` gem
+
+Add this to `~/.bashrc`, `_path` preffix avaiable for `p12` and `pem` only. If you need home path, use `ENV['HOME']` instead of `~`.
+
+```
+
+export GITLAB_API_HTTPARTY_OPTIONS="{verify: true, p12_path: '/path/to/key', p12_password_path: '/path/to/password' }"
+
+```

--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -161,6 +161,8 @@ module HTTParty
         else
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         end
+        
+        normalize_key_files options
 
         # Client certificate authentication
         # Note: options[:pem] must contain the content of a PEM file having the private key appended
@@ -193,6 +195,12 @@ module HTTParty
         if options[:ssl_version] && http.respond_to?(:ssl_version=)
           http.ssl_version = options[:ssl_version]
         end
+      end
+    end
+
+    def normalize_key_files options
+      %i[pem p12 pem_password p12_password].each do |o|
+        options[o] ||= File.read(options["#{o}_path".to_sym]).chomp if options["#{o}_path".to_sym]
       end
     end
   end


### PR DESCRIPTION
When I've tried to use https://github.com/NARKOZ/gitlab gem, I needed to serialize TLS options to global variable. It is very ugly, so, I added `_path` option for `p12` and `pem` for key and password files, so, user may store it in options directly, or use path. Syntax will be like `{ pem_path: '/path/to/cert'}`

I hope you'll like it 
