### PR TITLE
add spacing to example hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ class StackExchange
   base_uri 'api.stackexchange.com'
 
   def initialize(service, page)
-    @options = { query: {site: service, page: page} }
+    @options = { query: { site: service, page: page } }
   end
 
   def questions

--- a/examples/aaws.rb
+++ b/examples/aaws.rb
@@ -29,4 +29,4 @@ module AAWS
 end
 
 aaws = AAWS::Book.new(config[:access_key])
-pp aaws.search(query: {title: 'Ruby On Rails'})
+pp aaws.search(query: { title: 'Ruby On Rails' })

--- a/examples/crack.rb
+++ b/examples/crack.rb
@@ -16,4 +16,4 @@ class Rep
 end
 
 pp Rep.get('http://whoismyrepresentative.com/getall_mems.php?zip=46544')
-pp Rep.get('http://whoismyrepresentative.com/getall_mems.php', query: {zip: 46544})
+pp Rep.get('http://whoismyrepresentative.com/getall_mems.php', query: { zip: 46544 })

--- a/examples/custom_parsers.rb
+++ b/examples/custom_parsers.rb
@@ -21,7 +21,7 @@ class OnlyParseAtom
 
   # Only support Atom
   class Parser::OnlyAtom < HTTParty::Parser
-    SupportedFormats = {"application/atom+xml" => :atom}
+    SupportedFormats = { "application/atom+xml" => :atom }
 
     protected
 

--- a/examples/delicious.rb
+++ b/examples/delicious.rb
@@ -8,7 +8,7 @@ class Delicious
   base_uri 'https://api.del.icio.us/v1'
 
   def initialize(u, p)
-    @auth = {username: u, password: p}
+    @auth = { username: u, password: p }
   end
 
   # query params that filter the posts are:
@@ -17,7 +17,7 @@ class Delicious
   #   url (optional). Filter by this url.
   #   ie: posts(query: {tag: 'ruby'})
   def posts(options = {})
-    options.merge!({basic_auth: @auth})
+    options.merge!({ basic_auth: @auth })
     self.class.get('/posts/get', options)
   end
 
@@ -25,13 +25,13 @@ class Delicious
   #   tag (optional). Filter by this tag.
   #   count (optional). Number of items to retrieve (Default:15, Maximum:100).
   def recent(options = {})
-    options.merge!({basic_auth: @auth})
+    options.merge!({ basic_auth: @auth })
     self.class.get('/posts/recent', options)
   end
 end
 
 delicious = Delicious.new(config['username'], config['password'])
-pp delicious.posts(query: {tag: 'ruby'})
+pp delicious.posts(query: { tag: 'ruby' })
 pp delicious.recent
 
 delicious.recent['posts']['post'].each { |post| puts post['href'] }

--- a/examples/stackexchange.rb
+++ b/examples/stackexchange.rb
@@ -7,7 +7,7 @@ class StackExchange
   base_uri 'api.stackexchange.com'
 
   def initialize(service, page)
-    @options = { query: {site: service, page: page} }
+    @options = { query: { site: service, page: page } }
   end
 
   def questions

--- a/examples/tripit_sign_in.rb
+++ b/examples/tripit_sign_in.rb
@@ -24,7 +24,7 @@ class TripIt
   end
 
   def account_settings
-    self.class.get('/account/edit', headers: {'Cookie' => @cookie.to_cookie_string})
+    self.class.get('/account/edit', headers: { 'Cookie' => @cookie.to_cookie_string })
   end
 
   def logged_in?

--- a/examples/twitter.rb
+++ b/examples/twitter.rb
@@ -14,12 +14,12 @@ class Twitter
   # which can be :friends, :user or :public
   # options[:query] can be things like since, since_id, count, etc.
   def timeline(which = :friends, options = {})
-    options.merge!({basic_auth: @auth})
+    options.merge!({ basic_auth: @auth })
     self.class.get("/statuses/#{which}_timeline.json", options)
   end
 
   def post(text)
-    options = { query: {status: text}, basic_auth: @auth }
+    options = { query: { status: text }, basic_auth: @auth }
     self.class.post('/statuses/update.json', options)
   end
 end

--- a/examples/whoismyrep.rb
+++ b/examples/whoismyrep.rb
@@ -7,4 +7,4 @@ class Rep
 end
 
 pp Rep.get('http://whoismyrepresentative.com/getall_mems.php?zip=46544')
-pp Rep.get('http://whoismyrepresentative.com/getall_mems.php', query: {zip: 46544})
+pp Rep.get('http://whoismyrepresentative.com/getall_mems.php', query: { zip: 46544 })


### PR DESCRIPTION
Did this because the nested hashes with inconsistent styles was driving me mad. 

Also willing to create the reverse version as PR if deemed better, eg. always having no space between hash opening and closing brackets:

`{herp: derp}`

Just, please, one style 😄 