### PR TITLE
Update README with parsing JSON keys as symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,6 @@ puts stack_exchange.users
 
 See the [examples directory](http://github.com/jnunemaker/httparty/tree/master/examples) for even more goodies.
 
-## JSON Parsing
-If the response Content Type is `application/json`, HTTParty will parse the response and return Ruby objects such as a hash or array. The default behavior for parsing JSON will return keys as strings. This can be supressed with the `format` option. To get hash keys as symbols:
-
-```
-response = HTTParty.get('http://example.com', format: :plain)
-JSON.parse response, symbolize_names: true
-```
-
 ## Command Line Interface
 
 httparty also includes the executable `httparty` which can be

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ puts stack_exchange.users
 
 See the [examples directory](http://github.com/jnunemaker/httparty/tree/master/examples) for even more goodies.
 
+## JSON Parsing
+If the response Content Type is `application/json`, HTTParty will parse the response and return Ruby objects such as a hash or array. The default behavior for parsing JSON will return keys as strings. This can be supressed with the `format` option. To get hash keys as symbols:
+
+```
+response = HTTParty.get('http://example.com', format: :plain)
+JSON.parse response, symbolize_names: true
+```
+
 ## Command Line Interface
 
 httparty also includes the executable `httparty` which can be

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,16 @@
 Makes http fun again!
 
 ## Table of contents
+- [Parsing JSON](#parsing-json)
 - [Working with SSL](#working-with-ssl)
+
+## Parsing JSON
+If the response Content Type is `application/json`, HTTParty will parse the response and return Ruby objects such as a hash or array. The default behavior for parsing JSON will return keys as strings. This can be supressed with the `format` option. To get hash keys as symbols:
+
+```
+response = HTTParty.get('http://example.com', format: :plain)
+JSON.parse response, symbolize_names: true
+```
 
 ## Working with SSL
 


### PR DESCRIPTION
How to symbolize JSON keys or suppress parsing?

https://github.com/jnunemaker/httparty/issues/500