### PR TITLE
Fix numerous bugs, design issues, and documentation

### DIFF
--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -38,17 +38,31 @@ module HTTParty
   # in the #options attribute. It is up to you to interpret them within your
   # connection adapter. Take a look at the implementation of
   # HTTParty::ConnectionAdapter#connection for examples of how they are used.
-  # Some things that are probably interesting are as follows:
+  # The keys used in options are 
   # * :+timeout+: timeout in seconds
   # * :+open_timeout+: http connection open_timeout in seconds, overrides timeout if set
   # * :+read_timeout+: http connection read_timeout in seconds, overrides timeout if set
   # * :+debug_output+: see HTTParty::ClassMethods.debug_output.
-  # * :+pem+: contains pem data. see HTTParty::ClassMethods.pem.
+  # * :+cert_store+: contains certificate data. see method 'attach_ssl_certificates' 
+  # * :+pem+: contains pem client certificate data. see method 'attach_ssl_certificates'
+  # * :+p12+: contains PKCS12 client client certificate data.  see method 'attach_ssl_certificates'
   # * :+verify+: verify the server’s certificate against the ca certificate.
   # * :+verify_peer+: set to false to turn off server verification but still send client certificate
   # * :+ssl_ca_file+: see HTTParty::ClassMethods.ssl_ca_file.
   # * :+ssl_ca_path+: see HTTParty::ClassMethods.ssl_ca_path.
+  # * :+ssl_version+: SSL versions to allow. see method 'attach_ssl_certificates'
+  # * :+ciphers+: The list of SSL ciphers to support
   # * :+connection_adapter_options+: contains the hash you passed to HTTParty.connection_adapter when you configured your connection adapter
+  # * :+local_host+: The local address to bind to
+  # * :+local_port+: The local port to bind to
+  # * :+http_proxyaddr+: HTTP Proxy address
+  # * :+http_proxyport+: HTTP Proxy port
+  # * :+http_proxyuser+: HTTP Proxy user
+  # * :+http_proxypass+: HTTP Proxy password
+  #
+  # === Inherited methods
+  # * :+clean_host+: Method used to sanitize host names
+
   class ConnectionAdapter
     # Private: Regex used to strip brackets from IPv6 URIs.
     StripIpv6BracketsRegex = /\A\[(.*)\]\z/

--- a/lib/httparty/net_digest_auth.rb
+++ b/lib/httparty/net_digest_auth.rb
@@ -12,13 +12,13 @@ module Net
         response
       )
 
-      @header['Authorization'] = authenticator.authorization_header
-      @header['cookie'] = append_cookies(authenticator) if response['Set-Cookie']
-    end
+      authenticator.authorization_header.each do |v|
+        add_field('Authorization', v)
+      end 
 
-    def append_cookies(authenticator)
-      cookies = @header['cookie'] ? @header['cookie'] : []
-      cookies.concat(authenticator.cookie_header)
+      authenticator.cookie_header.each do |v|
+        add_field('Cookie', v)
+      end      
     end
 
     class DigestAuthenticator

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -232,10 +232,11 @@ module HTTParty
     end
 
     def encode_with_ruby_encoding(body, charset)
-      encoding = Encoding.find(charset)
-      body.force_encoding(encoding)
-    rescue
-      body
+      if Encoding.name_list.include?(charset)
+        body.force_encoding(charset)
+      else 
+        body
+      end 
     end
 
     def assume_utf16_is_big_endian

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -45,6 +45,7 @@ module HTTParty
       }.merge(o)
       self.path = path
       set_basic_auth_from_uri
+      @changed_hosts = false
     end
 
     def path=(uri)
@@ -337,7 +338,7 @@ module HTTParty
     end
 
     def send_authorization_header?
-      !defined?(@changed_hosts)
+      !@changed_hosts      
     end
 
     def response_redirects?

--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -59,6 +59,24 @@ module HTTParty
       response.nil? || response.body.nil? || response.body.empty?
     end
 
+    def to_s      
+      if !response.nil? && !response.body.nil? && response.body.respond_to?(:to_s)
+        response.body.to_s
+      else 
+        inspect
+      end
+    end
+
+    def display(port=$>)
+      if !parsed_response.nil? && parsed_response.respond_to?(:display)
+        parsed_response.display(port)
+      elsif !response.nil? && !response.body.nil? && response.body.respond_to?(:display)
+        response.body.display(port)
+      else 
+        port.write(inspect)
+      end
+    end
+
     def respond_to_missing?(name, *args)
       return true if super
       parsed_response.respond_to?(name) || response.respond_to?(name)

--- a/lib/httparty/response/headers.rb
+++ b/lib/httparty/response/headers.rb
@@ -1,30 +1,30 @@
 module HTTParty
   class Response #:nodoc:
-    class Headers
+    class Headers < ::SimpleDelegator
       include ::Net::HTTPHeader
 
-      def initialize(header = {})
-        @header = header
+      def initialize(header_values = nil)
+        @header = {}
+        if header_values
+          header_values.each_pair do |k,v|
+            if v.is_a?(Array)
+              v.each do |sub_v|
+                add_field(k, sub_v)
+              end
+            else
+              add_field(k, v)
+            end
+          end
+        end
+        super(@header)
       end
 
       def ==(other)
-        @header == other
-      end
-
-      def inspect
-        @header.inspect
-      end
-
-      def method_missing(name, *args, &block)
-        if @header.respond_to?(name)
-          @header.send(name, *args, &block)
-        else
-          super
+        if other.is_a?(::Net::HTTPHeader) 
+          @header == other.instance_variable_get(:@header)
+        elsif other.is_a?(Hash)
+          @header == other || @header == Headers.new(other).instance_variable_get(:@header)           
         end
-      end
-
-      def respond_to?(method, include_all = false)
-        super || @header.respond_to?(method, include_all)
       end
     end
   end

--- a/spec/httparty/net_digest_auth_spec.rb
+++ b/spec/httparty/net_digest_auth_spec.rb
@@ -17,6 +17,34 @@ RSpec.describe Net::HTTPHeader::DigestAuthenticator do
     @digest.cookie_header
   end
 
+  context 'Net::HTTPHeader#digest_auth' do
+    let(:headers) {
+      (Class.new do 
+        include Net::HTTPHeader
+        def initialize
+          @header = {}
+        end
+      end).new
+    } 
+
+    let(:response){
+      (Class.new do 
+        include Net::HTTPHeader
+        def initialize
+          @header = {}
+          self['WWW-Authenticate'] = 
+          'Digest realm="testrealm@host.com", qop="auth,auth-int", nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", opaque="5ccc069c403ebaf9f0171e9517f40e41"'
+        end
+      end).new
+    }
+
+    it 'should set the authorization header' do 
+      expect(headers['authorization']).to be_nil
+      headers.digest_auth('user','pass', response)
+      expect(headers['authorization']).to_not be_empty
+    end 
+  end 
+
   context "with a cookie value in the response header" do
     before do
       @digest = setup_digest({

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -187,8 +187,6 @@ RSpec.describe HTTParty::Request do
       end
 
       it 'should maintain cookies returned from a 401 response' do
-        require 'pry'
-
         @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}        
         response = @request.perform {|v|}
         expect(response.code).to eq(200)

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -1162,6 +1162,12 @@ RSpec.describe HTTParty::Request do
       expect(request.instance_variable_get(:@raw_request).decode_content).to eq(false)
     end
 
+    it 'should disable content decoding if present and lowercase' do 
+      request = HTTParty::Request.new(Net::HTTP::Get, 'http://api.foo.com/v1', headers:{'accept-encoding' => 'custom'})
+      request.send(:setup_raw_request)
+      expect(request.instance_variable_get(:@raw_request).decode_content).to eq(false)
+    end
+
     it 'should disable content decoding if present' do 
       request = HTTParty::Request.new(Net::HTTP::Get, 'http://api.foo.com/v1')
       request.send(:setup_raw_request)

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe HTTParty::Request do
       @request.send(:setup_raw_request)
 
       raw_request = @request.instance_variable_get(:@raw_request)
-      expect(raw_request.instance_variable_get(:@header)['Authorization']).not_to be_nil
+      expect(raw_request['Authorization']).not_to be_nil
     end
 
     it "should use the right http method for digest authentication" do
@@ -162,7 +162,7 @@ RSpec.describe HTTParty::Request do
       @request.send(:setup_raw_request)
 
       raw_request = @request.instance_variable_get(:@raw_request)
-      expect(raw_request.instance_variable_get(:@header)['cookie']).to eql ["custom-cookie=1234567"]
+      expect(raw_request.get_fields('cookie')).to eql ["custom-cookie=1234567"]
     end
 
     it 'should merge cookies from setup_digest_auth and request' do
@@ -177,7 +177,7 @@ RSpec.describe HTTParty::Request do
       @request.send(:setup_raw_request)
 
       raw_request = @request.instance_variable_get(:@raw_request)
-      expect(raw_request.instance_variable_get(:@header)['cookie']).to eql ['request-cookie=test', 'custom-cookie=1234567']
+      expect(raw_request.get_fields('cookie')).to eql ['request-cookie=test', 'custom-cookie=1234567']
     end
 
     it 'should use body_stream when configured' do

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -390,10 +390,15 @@ RSpec.describe HTTParty::Request do
 
     if "".respond_to?(:encoding)
 
+      let(:response_charset) {
+        @request.send(:get_charset)
+      }
+
       it "should process charset in content type properly" do
         response = stub_response "Content"
         response.initialize_http_header("Content-Type" => "text/plain;charset = utf-8")
         resp = @request.perform
+        expect(response_charset).to_not be_empty
         expect(resp.body.encoding).to eq(Encoding.find("UTF-8"))
       end
 
@@ -401,6 +406,7 @@ RSpec.describe HTTParty::Request do
         response = stub_response "Content"
         response.initialize_http_header("Content-Type" => "text/plain;CHARSET = utf-8")
         resp = @request.perform
+        expect(response_charset).to_not be_empty
         expect(resp.body.encoding).to eq(Encoding.find("UTF-8"))
       end
 
@@ -408,6 +414,7 @@ RSpec.describe HTTParty::Request do
         response = stub_response "Content"
         response.initialize_http_header("Content-Type" => "text/plain;charset = \"utf-8\"")
         resp = @request.perform
+        expect(response_charset).to_not be_empty
         expect(resp.body.encoding).to eq(Encoding.find("UTF-8"))
       end
 
@@ -417,6 +424,7 @@ RSpec.describe HTTParty::Request do
         response = stub_response "\xFF\xFEC\x00o\x00n\x00t\x00e\x00n\x00t\x00"
         response.initialize_http_header("Content-Type" => "text/plain;charset = utf-16")
         resp = @request.perform
+        expect(response_charset).to_not be_empty
         expect(resp.body.encoding).to eq(Encoding.find("UTF-16LE"))
       end
 
@@ -426,6 +434,7 @@ RSpec.describe HTTParty::Request do
         response = stub_response "\xFE\xFF\x00C\x00o\x00n\x00t\x00e\x00n\x00t"
         response.initialize_http_header("Content-Type" => "text/plain;charset = utf-16")
         resp = @request.perform
+        expect(response_charset).to_not be_empty
         expect(resp.body.encoding).to eq(Encoding.find("UTF-16BE"))
       end
 
@@ -435,6 +444,7 @@ RSpec.describe HTTParty::Request do
         response = stub_response "C\x00o\x00n\x00t\x00e\x00n\x00t\x00"
         response.initialize_http_header("Content-Type" => "text/plain;charset = utf-16")
         resp = @request.perform
+        expect(response_charset).to_not be_empty
         expect(resp.body.encoding).to eq(Encoding.find("UTF-16LE"))
       end
 
@@ -442,6 +452,9 @@ RSpec.describe HTTParty::Request do
         response = stub_response "Content"
         response.initialize_http_header("Content-Type" => "text/plain;charset = utf-lols")
         resp = @request.perform
+        expect(response_charset).to_not be_empty        
+        # This encoding does not exist, thus the string should not be encodd with it
+        expect(resp.body.encoding).to_not eq(response_charset)
         expect(resp.body).to eq("Content")
         expect(resp.body.encoding).to eq("Content".encoding)
       end
@@ -450,6 +463,7 @@ RSpec.describe HTTParty::Request do
         response = stub_response "Content"
         response.initialize_http_header("Content-Type" => "text/plain")
         resp = @request.perform
+        expect(response_charset).to be_nil
         expect(resp.body).to eq("Content")
         expect(resp.body.encoding).to eq("Content".encoding)
       end

--- a/spec/httparty/response_spec.rb
+++ b/spec/httparty/response_spec.rb
@@ -129,18 +129,33 @@ RSpec.describe HTTParty::Response do
     expect(response.respond_to?(:[])).to be_truthy
   end
 
-  it "should be able to iterate if it is array" do
-    response = HTTParty::Response.new(@request_object, @response_object, lambda { [{'foo' => 'bar'}, {'foo' => 'baz'}] })
-    expect(response.size).to eq(2)
-    expect {
-      response.each { |item| }
-    }.to_not raise_error
-  end
+  context 'response is array' do
+    let(:response_value) { [{'foo' => 'bar'}, {'foo' => 'baz'}] }
+    let(:response) { HTTParty::Response.new(@request_object, @response_object, lambda { response_value }) } 
+    it "should be able to iterate" do 
+      expect(response.size).to eq(2)
+      expect {
+        response.each { |item| }
+      }.to_not raise_error
+    end
 
-  it 'should respond to array methods if it is array' do 
-    response = HTTParty::Response.new(@request_object, @response_object, lambda { [{'foo' => 'bar'}, {'foo' => 'baz'}] })
-    expect(response).to respond_to(:bsearch, :compact, :cycle, :delete, :each, :flatten, :flatten!, :compact, :join)    
-  end  
+    it 'should respond to array methods' do       
+      expect(response).to respond_to(:bsearch, :compact, :cycle, :delete, :each, :flatten, :flatten!, :compact, :join)    
+    end
+
+    it 'should equal the string response object body' do
+      expect(response.to_s).to eq(@response_object.body.to_s)    
+    end    
+
+    it 'should display the same as an array' do
+      a = StringIO.new
+      b = StringIO.new
+      response_value.display(b)
+      response.display(a)
+
+      expect(a.string).to eq(b.string)    
+    end
+  end
 
   it "allows headers to be accessed by mixed-case names in hash notation" do
     response = HTTParty::Response.new(@request_object, @response_object, @parsed_response)

--- a/spec/httparty/response_spec.rb
+++ b/spec/httparty/response_spec.rb
@@ -263,9 +263,35 @@ RSpec.describe HTTParty::Response do
   end
 
   describe "headers" do
-    it "can initialize without headers" do
-      headers = HTTParty::Response::Headers.new
-      expect(headers).to eq({})
+    let (:empty_headers) { HTTParty::Response::Headers.new }
+    let (:some_headers_hash) do 
+      {'Cookie' => 'bob',
+      'Content-Encoding' => 'meow'}
+    end 
+    let (:some_headers) do 
+       HTTParty::Response::Headers.new.tap do |h|
+         some_headers_hash.each_pair do |k,v|
+           h[k] = v
+         end
+      end
+    end
+    it "can initialize without headers" do 
+      expect(empty_headers).to eq({})
+    end
+
+    it 'always equals itself' do
+      expect(empty_headers).to eq(empty_headers) 
+      expect(some_headers).to eq(some_headers)
+    end
+
+    it 'does not equal itself when not equivalent' do 
+      expect(empty_headers).to_not eq(some_headers)
+    end
+
+    it 'does equal a hash' do
+      expect(empty_headers).to eq({})
+
+      expect(some_headers).to eq(some_headers_hash)
     end
   end
 

--- a/spec/httparty/response_spec.rb
+++ b/spec/httparty/response_spec.rb
@@ -72,6 +72,18 @@ RSpec.describe HTTParty::Response do
     end
   end
 
+  it 'does raise an error about itself when using #method' do
+    expect {
+      HTTParty::Response.new(@request_object, @response_object, @parsed_response).method(:qux)
+    }.to raise_error(NameError, /HTTParty\:\:Response/)
+  end
+
+  it 'does raise an error about itself when invoking a method that does not exist' do 
+    expect {
+      HTTParty::Response.new(@request_object, @response_object, @parsed_response).qux
+    }.to raise_error(NoMethodError, /HTTParty\:\:Response/)
+  end 
+
   it "returns response headers" do
     response = HTTParty::Response.new(@request_object, @response_object, @parsed_response)
     expect(response.headers).to eq({'last-modified' => [@last_modified], 'content-length' => [@content_length]})
@@ -125,6 +137,11 @@ RSpec.describe HTTParty::Response do
     }.to_not raise_error
   end
 
+  it 'should respond to array methods if it is array' do 
+    response = HTTParty::Response.new(@request_object, @response_object, lambda { [{'foo' => 'bar'}, {'foo' => 'baz'}] })
+    expect(response).to respond_to(:bsearch, :compact, :cycle, :delete, :each, :flatten, :flatten!, :compact, :join)    
+  end  
+
   it "allows headers to be accessed by mixed-case names in hash notation" do
     response = HTTParty::Response.new(@request_object, @response_object, @parsed_response)
     expect(response.headers['Content-LENGTH']).to eq(@content_length)
@@ -151,8 +168,7 @@ RSpec.describe HTTParty::Response do
 
     it { is_expected.to respond_to(:is_a?).with(1).arguments }
     it { expect(subject.is_a?(HTTParty::Response)).to be_truthy }
-    it { expect(subject.is_a?(BasicObject)).to be_truthy }
-    it { expect(subject.is_a?(Object)).to be_falsey }
+    it { expect(subject.is_a?(Object)).to be_truthy }
   end
 
   describe "#kind_of?" do
@@ -160,8 +176,7 @@ RSpec.describe HTTParty::Response do
 
     it { is_expected.to respond_to(:kind_of?).with(1).arguments }
     it { expect(subject.kind_of?(HTTParty::Response)).to be_truthy }
-    it { expect(subject.kind_of?(BasicObject)).to be_truthy }
-    it { expect(subject.kind_of?(Object)).to be_falsey }
+    it { expect(subject.kind_of?(Object)).to be_truthy }
   end
 
   describe "semantic methods for response codes" do


### PR DESCRIPTION
Hi, I have been working with this library for about a week now and have found some problems

1. `HTTParty::Request#handle_deflation` does not do anything useful. In actuality, decompression is performed by `Net::HTTP.` The `Net::HTTP::GenericRequest` object has a 'decode_content' value (boolean) that the documentation says is false if 'Accept-Encoding' is specified. This is done with a check in the '[]=' operator on the class, but this isn't called. HTTParty uses the 'initialize_http_header' method, which does not perform this check. So decode_content is always true. When the `Net::HTTP::Response` object is instantiated, this is copied over. Then `Net::HTTP` performs the decompression. Not only is 'handle_deflation' dead code, there is already an implementation of this in Net::HTTP

Resolution: Remove 'handle_deflation' method and calls. If a caller specifies 'Accept-Encoding' header, then explicitly set it on the object so that Net::HTTP skips decompression.

2. The monkey patch in 'lib/httparty/net_digest_auth.rb' improperly manipulates `@header`. The `Net::HTTPHeader` object requires all keys in the `@header`
instance variable to be downcased, but this code adds headers with capital letters

Resolution: Call `add_field` as this does the correct thing without the caller having to worry about it. Use get_fields for access

3. `HTTParty::Request#setup_digest_auth` results in all requests being sent twice if the user specifies digest_auth. There is no way that this makes sense.

Resolution: Check for 401 and 'www-authenticate' header when considering the response. Resend the request if the user configured digest_auth and the server supports digest_auth

4. `HTTParty::Request#send_authorization_headers?` uses `self.defined` which is silly and error prone.

Resolution: set `@changed_hosts` to `false` in `initialize` method and use that value

5. `HTTParty::Request::Headers` defines the equality (`==`) operator without considering the downcased version of the right hand side.

Resolution: If the right hand side is a Net::HTTPHeader, compare against the `@header` variable of the right hand side object directly.
Use SimpleDelegator to forward methods to `@header`. If the right hand side is a has, convert the hash to an instance of ourselves and perform
the above comparison if the hash does not exactly equal our own `@header`

6. `HTTParty::Request#encode_with_ruby_encoding` rescues StandardError and completely suppresses the exception. In actuality, the only thing that can happen is `Encoding.find` may raise `ArgumentError`. The call to `#force_encoding` doesn't fail, because nothing actually happens at that time.

Resolution: Check 'Encoding.name_list.include?(charset)' before calling '#force_encoding'. No exception handling needed.

7. The documentation for `ConnectionAdapter.connection` is incomplete.

Resolution: List all the keys that need to be checked in the `options` hash by an implementation

8. `ConnectionAdapter.connection` does not document helper methods used by the existing implementation

Resolution: Add documentation about using `clean_host`

9. Trying to the `method` method on `HTTParty::Response` results in the most vexing of errors. such as stuff like this

```
[6] pry(main)> r.class
=> HTTParty::Response
[7] pry(main)> r.method(:qux)
NameError: undefined method `qux' for class `String'
from /home/ericu/.rvm/gems/ruby-2.3.0/gems/httparty-0.14.0/lib/httparty/response.rb:81:in `method'
```

This doesn't make any sort of logical sense given that I have a `Response`, not a string. It looks like for some reason this class inherits from BasicObject. There is a haphazard implementation of `respond_to?`, `class`, etc. It's far simpler to just define the methods needed and inherit from `Object`

Resolution: Switch base class to `Object`. Implement `nil?` so the object behaves like `nil` for an empty response. Implement `to_s`. Implement `display` .Remove un-needed implementations of other methods that `Object` provides.

Implement `respond_to_missing?` instead of `respond_to?`. Use `super` instead of `RESPOND_TO_METHODS.include?(method_name)`
Reference: http://blog.marc-andre.ca/2010/11/15/methodmissing-politely/


If you would like further elaboration on any of these issues or have questions just let me know.

Here is the output from running `bundle exec rake`:
https://gist.github.com/hydrogen18/23f812df0fd7679cb1694f772302f6ef