### PR TITLE
Do not overwrite default headers unless specified

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -212,10 +212,14 @@ module HTTParty
     #     include HTTParty
     #     headers 'Accept' => 'text/html'
     #   end
-    def headers(h = {})
-      raise ArgumentError, 'Headers must be an object which responds to #to_hash' unless h.respond_to?(:to_hash)
-      default_options[:headers] ||= {}
-      default_options[:headers].merge!(h.to_hash)
+    def headers(h = nil)
+      if h
+        raise ArgumentError, 'Headers must be an object which responds to #to_hash' unless h.respond_to?(:to_hash)
+        default_options[:headers] ||= {}
+        default_options[:headers].merge!(h.to_hash)
+      else
+        default_options[:headers] || {}
+      end
     end
 
     def cookies(h = {})

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -129,6 +129,11 @@ RSpec.describe HTTParty do
         .and_return(double("mock response", perform: nil))
     end
 
+    it "does not modify default_options when no arguments are passed" do
+      @klass.headers
+      expect(@klass.default_options[:headers]).to eq(nil)
+    end
+
     it "should default to empty hash" do
       expect(@klass.headers).to eq({})
     end
@@ -171,11 +176,11 @@ RSpec.describe HTTParty do
         @klass.get('', cookies: {type: 'snickerdoodle'})
       end
 
-      it 'doesnt modify default_options' do
+      it 'doesnt modify default headers' do
         expect(@klass.headers).to eq({})
         expect_headers('cookie' => 'type=snickerdoodle')
         @klass.get('', cookies: {type: 'snickerdoodle'})
-        expect(@klass.default_options[:headers]).to eq({})
+        expect(@klass.headers).to eq({})
       end
 
       it 'adds optional cookies to the optional headers' do


### PR DESCRIPTION
Previously, calling `HTTParty.headers` without an argument set
`HTTParty.default_options[:headers]` to an empty hash. Now the
default headers will only be set to an empty hash when one is
explicitly provided, otherwise they will remain `nil`.

The previous behavior was problematic because the default headers
for a request could either be `nil` or `{}`, depending on whether
`HTTParty.headers` had been called. When they are `nil` the
default headers from Net::HTTP are used.

@jnunemaker any feedback is appreciated! This feels to me like a bit more of a workaround than a real solution, but I don't see a cleaner solution without a somewhat larger refactor.

Thanks to @tomatoturnip for the original [PR](https://github.com/jnunemaker/httparty/pull/508).