### PR TITLE
Add JSON_API_QUERY_STRING_NORMALIZER

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -29,6 +29,19 @@ module HTTParty
       end.flatten.join('&')
     end
 
+    JSON_API_QUERY_STRING_NORMALIZER = proc do |query|
+      Array(query).sort_by { |a| a[0].to_s }.map do |key, value|
+        if value.nil?
+          key.to_s
+        elsif value.respond_to?(:to_ary)
+          values = value.to_ary.map{|v| ERB::Util.url_encode(v.to_s)}
+          "#{key}=#{values.join(',')}"
+        else
+          HashConversions.to_params(key => value)
+        end
+      end.flatten.join('&')
+    end
+
     attr_accessor :http_method, :options, :last_response, :redirect, :last_uri
     attr_reader :path
 


### PR DESCRIPTION
JSON API generally handles query string list parameters by comma-separating the values:

```
/articles?include=author&fields[articles]=title,body,author&fields[people]=name 
(with encoded '[' and ']' characters)
```

The default serializer and the `NON_RAILS_QUERY_STRING_NORMALIZER` currently creates duplicate query params with each value in a list:
```
Default
/articles?include=author&fields[articles][]=title&fields[articles][]=body&fields[articles][]=author&fields[people]=name 
NON_RAILS
/articles?include=author&fields[articles]=title&fields[articles]=body&fields[articles]=author&fields[people]=name 
```

This PR adds another query string normalizer that will produce URLs of the first format, which will work out of the box with JSON API-compliant APIs.
