### PR TITLE
[#498] Handle utf-8 bom for json parsing

### DIFF
--- a/lib/httparty/parser.rb
+++ b/lib/httparty/parser.rb
@@ -114,8 +114,10 @@ module HTTParty
       MultiXml.parse(body)
     end
 
+    UTF8_BOM = "\xEF\xBB\xBF".freeze
+
     def json
-      JSON.parse(body, :quirks_mode => true, :allow_nan => true)
+      JSON.parse(body.gsub(/^#{UTF8_BOM}/, ''), :quirks_mode => true, :allow_nan => true)
     end
 
     def csv

--- a/spec/httparty/parser_spec.rb
+++ b/spec/httparty/parser_spec.rb
@@ -103,6 +103,11 @@ RSpec.describe HTTParty::Parser do
       allow(@parser).to receive_messages(supports_format?: false)
       expect(@parser.parse).to_not be_nil
     end
+
+    it "ignores utf-8 bom" do
+      allow(@parser).to receive_messages(body: "\xEF\xBB\xBF\{\"hi\":\"yo\"\}")
+      expect(@parser.parse).to eq({"hi"=>"yo"})
+    end
   end
 
   describe "#supports_format?" do

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -368,6 +368,12 @@ RSpec.describe HTTParty::Request do
       expect(@request.send(:parse_response, xml)).to eq({'books' => {'book' => {'id' => '1234', 'name' => 'Foo Bar!'}}})
     end
 
+    it 'should handle utf-8 bom in xml' do
+      xml = "\xEF\xBB\xBF<books><book><id>1234</id><name>Foo Bar!</name></book></books>"
+      @request.options[:format] = :xml
+      expect(@request.send(:parse_response, xml)).to eq({'books' => {'book' => {'id' => '1234', 'name' => 'Foo Bar!'}}})
+    end
+
     it 'should handle csv automatically' do
       csv = ['"id","Name"', '"1234","Foo Bar!"'].join("\n")
       @request.options[:format] = :csv
@@ -376,6 +382,12 @@ RSpec.describe HTTParty::Request do
 
     it 'should handle json automatically' do
       json = '{"books": {"book": {"name": "Foo Bar!", "id": "1234"}}}'
+      @request.options[:format] = :json
+      expect(@request.send(:parse_response, json)).to eq({'books' => {'book' => {'id' => '1234', 'name' => 'Foo Bar!'}}})
+    end
+
+    it 'should handle utf-8 bom in json' do
+      json = "\xEF\xBB\xBF{\"books\": {\"book\": {\"name\": \"Foo Bar!\", \"id\": \"1234\"}}}"
       @request.options[:format] = :json
       expect(@request.send(:parse_response, json)).to eq({'books' => {'book' => {'id' => '1234', 'name' => 'Foo Bar!'}}})
     end


### PR DESCRIPTION
Closes #498 

Currently, HTTParty errors when you try to parse JSON that has a utf-8 BOM. Since .NET applications automatically prepend the BOM characters, this severely limits the usefulness of HTTParty when talking to Windows-based JSON services.

This PR resolves that issue by stripping the BOM characters before parsing the JSON response.