### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ rvm:
   - 2.1.8
   - 2.2.4
   - 2.3.0
+  - 2.4.0
 bundler_args: --without development
 before_install: gem install bundler


### PR DESCRIPTION
Adding Ruby 2.4.0 as I got this error:
```
/Users/*****/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/specification.rb:2288:in `raise_if_conflicts': Unable to activate httparty-0.13.7, because json-2.1.0 conflicts with json (~> 1.8) (Gem::ConflictError)
	from /Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/specification.rb:1408:in `activate'
	from /Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/specification.rb:1442:in `block in activate_dependencies'
	from /Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/specification.rb:1428:in `each'
	from /Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/specification.rb:1428:in `activate_dependencies'
	from /Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/specification.rb:1410:in `activate'
	from /Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems.rb:220:in `rescue in try_activate'
	from /Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems.rb:213:in `try_activate'
	from /Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:126:in `rescue in require'
	from /Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:40:in `require'
```