### PR TITLE
exclude spec

### DIFF
--- a/httparty.gemspec
+++ b/httparty.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   # If this line is removed, all hard partying will cease.
   s.post_install_message = "When you HTTParty, you must party hard!"
 
-  s.files         = `git ls-files`.split("\n")
+  s.files         = `git ls-files | grep -v ^spec`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]


### PR DESCRIPTION
you're using a symlink in your spec
https://github.com/ahorek/httparty/blob/master/spec/fixtures/ssl/generated/1fe462c2.0

on Windows you can't install this gem on Ruby < 2.2 at all and on Ruby 2.2 you need administrator rights. But this gem should be compatible with Ruby 2.0+, am I right?
This commit removes specs from .gem file which will solve the issue.

```
/lib/ruby/site_ruby/2.1.0/rubygems/package.rb:388:in `symlink': symlink() function is unimplemented on this machine (NotImplementedError)
        from /lib/ruby/site_ruby/2.1.0/rubygems/package.rb:388:in `block (2 levels) in extract_tar_gz'
        from /lib/ruby/site_ruby/2.1.0/rubygems/package/tar_reader.rb:65:in `each'
        from /lib/ruby/site_ruby/2.1.0/rubygems/package.rb:365:in `block in extract_tar_gz'
        from/lib/ruby/site_ruby/2.1.0/rubygems/package.rb:459:in `block in open_tar_gz'
        from /lib/ruby/site_ruby/2.1.0/rubygems/package.rb:456:in `wrap'
        from /lib/ruby/site_ruby/2.1.0/rubygems/package.rb:456:in `open_tar_gz'
        from /lib/ruby/site_ruby/2.1.0/rubygems/package.rb:364:in `extract_tar_gz'
        from /lib/ruby/site_ruby/2.1.0/rubygems/package.rb:345:in `block (2 levels) in extract_files'
        from /lib/ruby/site_ruby/2.1.0/rubygems/package/tar_reader.rb:65:in `each'
        from/lib/ruby/site_ruby/2.1.0/rubygems/package.rb:342:in `block in extract_files'
```