### PR TITLE
Handle an HTTP Response with a Content-type but no body.

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -276,7 +276,7 @@ module HTTParty
     end
 
     def encode_with_ruby_encoding(body, charset)
-      if Encoding.name_list.include?(charset)
+      if !body.nil? && Encoding.name_list.include?(charset)
         body.force_encoding(charset)
       else 
         body

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -485,6 +485,13 @@ RSpec.describe HTTParty::Request do
         expect(resp.body.encoding).to eq(Encoding.find("UTF-8"))
       end
 
+      it "should process response with a nil body" do
+        response = stub_response nil
+        response.initialize_http_header("Content-Type" => "text/html;charset=UTF-8")
+        resp = @request.perform
+        expect(resp.body).to be_nil
+      end
+
       it "should process utf-16 charset with little endian bom correctly" do
         @request.options[:assume_utf16_is_big_endian] = true
 


### PR DESCRIPTION
In c46663d73ff96d86b92d36208a021bbe58672e7c a change was made to clean up the `encode_with_ruby_encoding` method. 

Previously, the `force_encoding` method was always called and then there was a `rescue` that would just return the `body`. If a request had a `nil` body, the `rescue` made sure that a `nil` value (the original `body`) would be returned.

After c46663d73ff96d86b92d36208a021bbe58672e7c, if a response had a `nil` body, an error would be thrown when parsing the response.

This PR includes a spec that reproduces the error and a fix that adds a `nil` check to make sure we do not call `force_encoding` on `nil`. If the `body` is `nil`, we will return `nil`. This matches the previous behavior.