### PR TITLE
Add missing require to headers.rb

### DIFF
--- a/lib/httparty/response/headers.rb
+++ b/lib/httparty/response/headers.rb
@@ -1,3 +1,5 @@
+require 'delegate'
+
 module HTTParty
   class Response #:nodoc:
     class Headers < ::SimpleDelegator


### PR DESCRIPTION
The delegate library is not auto-required in Ruby 2.2.x, so we need to explicitly require it if we are using SimpleDelegator.