### PR TITLE
Bugfix: Don't attempt to call force_encoding on nil objects.

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -276,11 +276,11 @@ module HTTParty
     end
 
     def encode_with_ruby_encoding(body, charset)
-      if Encoding.name_list.include?(charset)
+      if Encoding.name_list.include?(charset) && !body.nil?
         body.force_encoding(charset)
-      else 
+      else
         body
-      end 
+      end
     end
 
     def assume_utf16_is_big_endian

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -534,6 +534,13 @@ RSpec.describe HTTParty::Request do
         expect(resp.body).to eq("Content")
         expect(resp.body.encoding).to eq("Content".encoding)
       end
+
+      it "should not attempt encoding if the body is empty" do
+        response = stub_response nil
+        response.initialize_http_header("Content-Type" => "text/plain;charset = UTF-8")
+        resp = @request.perform
+        expect(resp.body).to be_nil
+      end
     end
 
     describe 'with non-200 responses' do


### PR DESCRIPTION
This should fix HEAD requests, where the body will be nil.
Fixes issue #534.