### PR TITLE
[#533] Prevent gsub errors with different encodings

### DIFF
--- a/lib/httparty/parser.rb
+++ b/lib/httparty/parser.rb
@@ -101,6 +101,9 @@ module HTTParty
       return nil if body.nil?
       return nil if body == "null"
       return nil if body.valid_encoding? && body.strip.empty?
+      if body.valid_encoding? && body.encoding == Encoding::UTF_8
+        body.gsub!(/\A#{UTF8_BOM}/, '')
+      end
       if supports_format?
         parse_supported_format
       else
@@ -117,7 +120,7 @@ module HTTParty
     UTF8_BOM = "\xEF\xBB\xBF".freeze
 
     def json
-      JSON.parse(body.gsub(/\A#{UTF8_BOM}/, ''), :quirks_mode => true, :allow_nan => true)
+      JSON.parse(body, :quirks_mode => true, :allow_nan => true)
     end
 
     def csv

--- a/spec/httparty/parser_spec.rb
+++ b/spec/httparty/parser_spec.rb
@@ -108,6 +108,13 @@ RSpec.describe HTTParty::Parser do
       allow(@parser).to receive_messages(body: "\xEF\xBB\xBF\{\"hi\":\"yo\"\}")
       expect(@parser.parse).to eq({"hi"=>"yo"})
     end
+
+    it "parses ascii 8bit encoding" do
+      allow(@parser).to receive_messages(
+        body: "{\"currency\":\"\xE2\x82\xAC\"}".force_encoding('ASCII-8BIT')
+      )
+      expect(@parser.parse).to eq({"currency" => "€"})
+    end
   end
 
   describe "#supports_format?" do


### PR DESCRIPTION
Closes #533 

Fixes an issue where ASCII-8BIT encodings blow up with a `gsub` call to strip the UTF8 BOM.