### PR TITLE
[#539] Use non-destructive gsub, fix test stubbing

### DIFF
--- a/lib/httparty/parser.rb
+++ b/lib/httparty/parser.rb
@@ -102,7 +102,7 @@ module HTTParty
       return nil if body == "null"
       return nil if body.valid_encoding? && body.strip.empty?
       if body.valid_encoding? && body.encoding == Encoding::UTF_8
-        body.gsub!(/\A#{UTF8_BOM}/, '')
+        @body = body.gsub(/\A#{UTF8_BOM}/, '')
       end
       if supports_format?
         parse_supported_format


### PR DESCRIPTION
Closes #539

Apparently I like breaking stuff with my changes 😭 . This PR fixes `gsub!` from breaking on frozen string literals.

Some of the tests around this were actually stubbing the `body` call directly, instead of setting the data. I've changed these tests to inject the data instead. As a high-level note, a lot of tests for `Parser` are stubbing private methods, which I don't think is a good way to structure tests.

We should be able to test all use cases of `Parser` through the external API. When we stub, or test directly, internal methods, any implementation change can break any number of other tests, even if the change doesn't affect external behavior.