### PR TITLE
Ensure correct encoding is used for Content-Types that are lower-case or aliases

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -276,11 +276,10 @@ module HTTParty
     end
 
     def encode_with_ruby_encoding(body, charset)
-      if !body.nil? && Encoding.name_list.include?(charset)
-        body.force_encoding(charset)
-      else
-        body
-      end
+      encoding = Encoding.find(charset)
+      body.force_encoding(charset)
+    rescue ArgumentError
+      body
     end
 
     def assume_utf16_is_big_endian

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -157,46 +157,46 @@ RSpec.describe HTTParty::Request do
       expect(@request.instance_variable_get(:@raw_request)['authorization']).not_to be_nil
     end
 
-    context 'digest_auth' do 
-      before do 
+    context 'digest_auth' do
+      before do
         response_sequence = [
-          {status: ['401', 'Unauthorized' ], 
+          {status: ['401', 'Unauthorized' ],
             www_authenticate: 'Digest realm="Log Viewer", qop="auth", nonce="2CA0EC6B0E126C4800E56BA0C0003D3C", opaque="5ccc069c403ebaf9f0171e9517f40e41", stale=false',
-            set_cookie: 'custom-cookie=1234567', 
+            set_cookie: 'custom-cookie=1234567',
           },
           {status: ['200', 'OK']}
-        ]      
+        ]
         FakeWeb.register_uri(:get, "http://api.foo.com/v1",
                             response_sequence)
-      end 
+      end
 
       it 'should not send credentials more than once' do
         response_sequence = [
-          {status: ['401', 'Unauthorized' ], 
+          {status: ['401', 'Unauthorized' ],
             www_authenticate: 'Digest realm="Log Viewer", qop="auth", nonce="2CA0EC6B0E126C4800E56BA0C0003D3C", opaque="5ccc069c403ebaf9f0171e9517f40e41", stale=false',
-            set_cookie: 'custom-cookie=1234567', 
+            set_cookie: 'custom-cookie=1234567',
           },
-          {status: ['401', 'Unauthorized' ], 
+          {status: ['401', 'Unauthorized' ],
             www_authenticate: 'Digest realm="Log Viewer", qop="auth", nonce="2CA0EC6B0E126C4800E56BA0C0003D3C", opaque="5ccc069c403ebaf9f0171e9517f40e41", stale=false',
-            set_cookie: 'custom-cookie=1234567', 
-          },      
+            set_cookie: 'custom-cookie=1234567',
+          },
           {status: ['404', 'Not found']}
-        ]      
+        ]
         FakeWeb.register_uri(:get, "http://api.foo.com/v1",
                             response_sequence)
 
-        @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}        
+        @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}
         response = @request.perform { |v| }
         expect(response.code).to eq(401)
 
         raw_request = @request.instance_variable_get(:@raw_request)
-        expect(raw_request['Authorization']).not_to be_nil                    
-      end 
+        expect(raw_request['Authorization']).not_to be_nil
+      end
 
       it 'should not be used when configured and the response is 200' do
         FakeWeb.register_uri(:get, "http://api.foo.com/v1",
           status: 200)
-        @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}        
+        @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}
         response = @request.perform { |v| }
         expect(response.code).to eq(200)
 
@@ -206,7 +206,7 @@ RSpec.describe HTTParty::Request do
       end
 
       it "should be used when configured and the response is 401" do
-        @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}        
+        @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}
         response = @request.perform { |v| }
         expect(response.code).to eq(200)
 
@@ -215,16 +215,16 @@ RSpec.describe HTTParty::Request do
       end
 
       it 'should maintain cookies returned from a 401 response' do
-        @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}        
+        @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}
         response = @request.perform {|v|}
         expect(response.code).to eq(200)
-        
+
         raw_request = @request.instance_variable_get(:@raw_request)
         expect(raw_request.get_fields('cookie')).to eql ["custom-cookie=1234567"]
       end
 
       it 'should merge cookies from request and a 401 response' do
-        
+
         @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}
         @request.options[:headers] = {'cookie' => 'request-cookie=test'}
         response = @request.perform {|v|}
@@ -462,7 +462,7 @@ RSpec.describe HTTParty::Request do
       }
 
       it "should process charset in content type properly" do
-        response = stub_response "Content"
+        response = stub_response "Content".force_encoding('ascii-8bit')
         response.initialize_http_header("Content-Type" => "text/plain;charset = utf-8")
         resp = @request.perform
         expect(response_charset).to_not be_empty
@@ -470,7 +470,7 @@ RSpec.describe HTTParty::Request do
       end
 
       it "should process charset in content type properly if it has a different case" do
-        response = stub_response "Content"
+        response = stub_response "Content".force_encoding('ascii-8bit')
         response.initialize_http_header("Content-Type" => "text/plain;CHARSET = utf-8")
         resp = @request.perform
         expect(response_charset).to_not be_empty
@@ -478,7 +478,7 @@ RSpec.describe HTTParty::Request do
       end
 
       it "should process quoted charset in content type properly" do
-        response = stub_response "Content"
+        response = stub_response "Content".force_encoding('ascii-8bit')
         response.initialize_http_header("Content-Type" => "text/plain;charset = \"utf-8\"")
         resp = @request.perform
         expect(response_charset).to_not be_empty
@@ -526,7 +526,7 @@ RSpec.describe HTTParty::Request do
         response = stub_response "Content"
         response.initialize_http_header("Content-Type" => "text/plain;charset = utf-lols")
         resp = @request.perform
-        expect(response_charset).to_not be_empty        
+        expect(response_charset).to_not be_empty
         # This encoding does not exist, thus the string should not be encodd with it
         expect(resp.body.encoding).to_not eq(response_charset)
         expect(resp.body).to eq("Content")
@@ -1230,19 +1230,19 @@ RSpec.describe HTTParty::Request do
   end
 
   context 'with Accept-Encoding header' do
-    it 'should disable content decoding if present' do 
+    it 'should disable content decoding if present' do
       request = HTTParty::Request.new(Net::HTTP::Get, 'http://api.foo.com/v1', headers:{'Accept-Encoding' => 'custom'})
       request.send(:setup_raw_request)
       expect(request.instance_variable_get(:@raw_request).decode_content).to eq(false)
     end
 
-    it 'should disable content decoding if present and lowercase' do 
+    it 'should disable content decoding if present and lowercase' do
       request = HTTParty::Request.new(Net::HTTP::Get, 'http://api.foo.com/v1', headers:{'accept-encoding' => 'custom'})
       request.send(:setup_raw_request)
       expect(request.instance_variable_get(:@raw_request).decode_content).to eq(false)
     end
 
-    it 'should disable content decoding if present' do 
+    it 'should disable content decoding if present' do
       request = HTTParty::Request.new(Net::HTTP::Get, 'http://api.foo.com/v1')
       request.send(:setup_raw_request)
       expect(request.instance_variable_get(:@raw_request).decode_content).to eq(true)


### PR DESCRIPTION
Somewhere along the line, it looks like responses stopped getting the encoding specified by the `Content-Type` header applied unless the header’s value was an exact, case-sensitive match for an encoding’s name in Ruby.

In a lot of real-world scenarios, encodings will be referenced in lower-case (internally, they are all upper-case in Ruby) or by other well-known aliases, e.g. `eucKR` is an alias for `EUC-KR` and `CP65001` is an alias for `UTF-8`.

This also updates tests—they were previously passing erroneously and didn’t *actually* test the behavior they were meant to. Test values were already correct and didn’t need the behavior the tests were looking for to be applied.

This fixes #542 and possibly #541.