### PR TITLE
Replaces Fakeweb with Webmock in tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ rvm:
   - 2.1.8
   - 2.2.4
   - 2.3.0
+  - 2.4.1
 bundler_args: --without development
 before_install: gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
-gem 'fakeweb',  '~> 1.3'
 gem 'mongrel',  '1.2.0.pre2'
 
 group :development do
@@ -16,4 +15,5 @@ group :test do
   gem 'simplecov', require: false
   gem 'aruba'
   gem 'cucumber', '~> 2.3'
+  gem 'webmock'
 end

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -157,46 +157,47 @@ RSpec.describe HTTParty::Request do
       expect(@request.instance_variable_get(:@raw_request)['authorization']).not_to be_nil
     end
 
-    context 'digest_auth' do 
-      before do 
+    context 'digest_auth' do
+      before do
         response_sequence = [
-          {status: ['401', 'Unauthorized' ], 
+          {status: ['401', 'Unauthorized' ], headers: {
             www_authenticate: 'Digest realm="Log Viewer", qop="auth", nonce="2CA0EC6B0E126C4800E56BA0C0003D3C", opaque="5ccc069c403ebaf9f0171e9517f40e41", stale=false',
-            set_cookie: 'custom-cookie=1234567', 
+            set_cookie: 'custom-cookie=1234567',
+            }
           },
           {status: ['200', 'OK']}
-        ]      
-        FakeWeb.register_uri(:get, "http://api.foo.com/v1",
-                            response_sequence)
-      end 
+        ]
+        stub_request(:get, "http://api.foo.com/v1").and_return(response_sequence)
+      end
 
       it 'should not send credentials more than once' do
         response_sequence = [
-          {status: ['401', 'Unauthorized' ], 
+          {status: ['401', 'Unauthorized' ], headers: {
             www_authenticate: 'Digest realm="Log Viewer", qop="auth", nonce="2CA0EC6B0E126C4800E56BA0C0003D3C", opaque="5ccc069c403ebaf9f0171e9517f40e41", stale=false',
-            set_cookie: 'custom-cookie=1234567', 
+            set_cookie: 'custom-cookie=1234567'
+            }
           },
-          {status: ['401', 'Unauthorized' ], 
+          {status: ['401', 'Unauthorized' ], headers: {
             www_authenticate: 'Digest realm="Log Viewer", qop="auth", nonce="2CA0EC6B0E126C4800E56BA0C0003D3C", opaque="5ccc069c403ebaf9f0171e9517f40e41", stale=false',
-            set_cookie: 'custom-cookie=1234567', 
-          },      
+            set_cookie: 'custom-cookie=1234567'
+            }
+          },
           {status: ['404', 'Not found']}
-        ]      
-        FakeWeb.register_uri(:get, "http://api.foo.com/v1",
+        ]
+        stub_request(:get, "http://api.foo.com/v1").and_return(
                             response_sequence)
 
-        @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}        
+        @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}
         response = @request.perform { |v| }
         expect(response.code).to eq(401)
 
         raw_request = @request.instance_variable_get(:@raw_request)
-        expect(raw_request['Authorization']).not_to be_nil                    
-      end 
+        expect(raw_request['Authorization']).not_to be_nil
+      end
 
       it 'should not be used when configured and the response is 200' do
-        FakeWeb.register_uri(:get, "http://api.foo.com/v1",
-          status: 200)
-        @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}        
+        stub_request(:get, "http://api.foo.com/v1").and_return(status: 200)
+        @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}
         response = @request.perform { |v| }
         expect(response.code).to eq(200)
 
@@ -206,7 +207,7 @@ RSpec.describe HTTParty::Request do
       end
 
       it "should be used when configured and the response is 401" do
-        @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}        
+        @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}
         response = @request.perform { |v| }
         expect(response.code).to eq(200)
 
@@ -215,16 +216,16 @@ RSpec.describe HTTParty::Request do
       end
 
       it 'should maintain cookies returned from a 401 response' do
-        @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}        
+        @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}
         response = @request.perform {|v|}
         expect(response.code).to eq(200)
-        
+
         raw_request = @request.instance_variable_get(:@raw_request)
         expect(raw_request.get_fields('cookie')).to eql ["custom-cookie=1234567"]
       end
 
       it 'should merge cookies from request and a 401 response' do
-        
+
         @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}
         @request.options[:headers] = {'cookie' => 'request-cookie=test'}
         response = @request.perform {|v|}
@@ -243,7 +244,7 @@ RSpec.describe HTTParty::Request do
     end
 
     it 'should normalize base uri when specified as request option' do
-      FakeWeb.register_uri(:get, 'http://foo.com/resource', :body => 'Bar')
+      stub_request(:get, 'http://foo.com/resource').to_return(:body => 'Bar')
       response = HTTParty.get('/resource', {
         base_uri: 'foo.com'
       })
@@ -526,7 +527,7 @@ RSpec.describe HTTParty::Request do
         response = stub_response "Content"
         response.initialize_http_header("Content-Type" => "text/plain;charset = utf-lols")
         resp = @request.perform
-        expect(response_charset).to_not be_empty        
+        expect(response_charset).to_not be_empty
         # This encoding does not exist, thus the string should not be encodd with it
         expect(resp.body.encoding).to_not eq(response_charset)
         expect(resp.body).to eq("Content")
@@ -568,8 +569,8 @@ RSpec.describe HTTParty::Request do
 
         it "calls block given to perform with each redirect" do
           @request = HTTParty::Request.new(Net::HTTP::Get, 'http://test.com/redirect', format: :xml)
-          FakeWeb.register_uri(:get, "http://test.com/redirect", status: [300, "REDIRECT"], location: "http://api.foo.com/v2")
-          FakeWeb.register_uri(:get, "http://api.foo.com/v2", body: "<hash><foo>bar</foo></hash>")
+          stub_request(:get, "http://test.com/redirect").and_return(status: [300, "REDIRECT"], headers: { location: "http://api.foo.com/v2" })
+          stub_request(:get, "http://api.foo.com/v2").and_return(body: "<hash><foo>bar</foo></hash>")
           body = ""
           response = @request.perform { |chunk| body += chunk }
           expect(body.length).to eq(27)
@@ -590,9 +591,9 @@ RSpec.describe HTTParty::Request do
 
         it "handles multiple redirects and relative location headers on different hosts" do
           @request = HTTParty::Request.new(Net::HTTP::Get, 'http://test.com/redirect', format: :xml)
-          FakeWeb.register_uri(:get, "http://test.com/redirect", status: [300, "REDIRECT"], location: "http://api.foo.com/v2")
-          FakeWeb.register_uri(:get, "http://api.foo.com/v2", status: [300, "REDIRECT"], location: "/v3")
-          FakeWeb.register_uri(:get, "http://api.foo.com/v3", body: "<hash><foo>bar</foo></hash>")
+          stub_request(:get, "http://test.com/redirect").and_return(status: [300, "REDIRECT"], headers: { location: "http://api.foo.com/v2" })
+          stub_request(:get, "http://api.foo.com/v2").and_return(status: [300, "REDIRECT"], headers: { location: "/v3" })
+          stub_request(:get, "http://api.foo.com/v3").and_return(body: "<hash><foo>bar</foo></hash>")
           response = @request.perform
           expect(response.request.base_uri.to_s).to eq("http://api.foo.com")
           expect(response.request.path.to_s).to eq("/v3")
@@ -603,7 +604,7 @@ RSpec.describe HTTParty::Request do
 
         it "raises an error if redirect has duplicate location header" do
           @request = HTTParty::Request.new(Net::HTTP::Get, 'http://test.com/redirect', format: :xml)
-          FakeWeb.register_uri(:get, "http://test.com/redirect", status: [300, "REDIRECT"], location: ["http://api.foo.com/v2","http://api.foo.com/v2"])
+          stub_request(:get, "http://test.com/redirect").and_return(status: [300, "REDIRECT"], headers: { location: ["http://api.foo.com/v2","http://api.foo.com/v2"] })
           expect {@request.perform}.to raise_error(HTTParty::DuplicateLocationHeader)
         end
 
@@ -613,8 +614,8 @@ RSpec.describe HTTParty::Request do
         end
 
         it "redirects including port" do
-          FakeWeb.register_uri(:get, "http://withport.com:3000/v1", status: [301, "Moved Permanently"], location: "http://withport.com:3000/v2")
-          FakeWeb.register_uri(:get, "http://withport.com:3000/v2", status: 200)
+          stub_request(:get, "http://withport.com:3000/v1").and_return(status: [301, "Moved Permanently"], headers: { location: "http://withport.com:3000/v2" })
+          stub_request(:get, "http://withport.com:3000/v2").and_return(status: 200)
           request = HTTParty::Request.new(Net::HTTP::Get, 'http://withport.com:3000/v1')
           response = request.perform
           expect(response.request.base_uri.to_s).to eq("http://withport.com:3000")
@@ -1230,19 +1231,19 @@ RSpec.describe HTTParty::Request do
   end
 
   context 'with Accept-Encoding header' do
-    it 'should disable content decoding if present' do 
+    it 'should disable content decoding if present' do
       request = HTTParty::Request.new(Net::HTTP::Get, 'http://api.foo.com/v1', headers:{'Accept-Encoding' => 'custom'})
       request.send(:setup_raw_request)
       expect(request.instance_variable_get(:@raw_request).decode_content).to eq(false)
     end
 
-    it 'should disable content decoding if present and lowercase' do 
+    it 'should disable content decoding if present and lowercase' do
       request = HTTParty::Request.new(Net::HTTP::Get, 'http://api.foo.com/v1', headers:{'accept-encoding' => 'custom'})
       request.send(:setup_raw_request)
       expect(request.instance_variable_get(:@raw_request).decode_content).to eq(false)
     end
 
-    it 'should disable content decoding if present' do 
+    it 'should disable content decoding if present' do
       request = HTTParty::Request.new(Net::HTTP::Get, 'http://api.foo.com/v1')
       request.send(:setup_raw_request)
       expect(request.instance_variable_get(:@raw_request).decode_content).to eq(true)

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe HTTParty::Request do
           },
           { status: ['200', 'OK'] }
         ]
-        stub_request(:get, 'http://api.foo.com/v1').and_return(response_sequence)
+        stub_request(:get, 'http://api.foo.com/v1').to_return(response_sequence)
       end
 
       it 'should not send credentials more than once' do
@@ -187,7 +187,7 @@ RSpec.describe HTTParty::Request do
           },
           { status: ['404', 'Not found'] }
         ]
-        stub_request(:get, 'http://api.foo.com/v1').and_return(response_sequence)
+        stub_request(:get, 'http://api.foo.com/v1').to_return(response_sequence)
 
         @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}
         response = @request.perform { |v| }
@@ -198,7 +198,7 @@ RSpec.describe HTTParty::Request do
       end
 
       it 'should not be used when configured and the response is 200' do
-        stub_request(:get, 'http://api.foo.com/v1').and_return(status: 200)
+        stub_request(:get, 'http://api.foo.com/v1').to_return(status: 200)
         @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}
         response = @request.perform { |v| }
         expect(response.code).to eq(200)
@@ -572,12 +572,12 @@ RSpec.describe HTTParty::Request do
         it "calls block given to perform with each redirect" do
           @request = HTTParty::Request.new(Net::HTTP::Get, 'http://test.com/redirect', format: :xml)
           stub_request(:get, 'http://test.com/redirect')
-            .and_return(
+            .to_return(
               status: [300, 'REDIRECT'],
               headers: { location: 'http://api.foo.com/v2' }
             )
           stub_request(:get, 'http://api.foo.com/v2')
-            .and_return(body: '<hash><foo>bar</foo></hash>')
+            .to_return(body: '<hash><foo>bar</foo></hash>')
           body = ""
           response = @request.perform { |chunk| body += chunk }
           expect(body.length).to eq(27)
@@ -599,17 +599,17 @@ RSpec.describe HTTParty::Request do
         it "handles multiple redirects and relative location headers on different hosts" do
           @request = HTTParty::Request.new(Net::HTTP::Get, 'http://test.com/redirect', format: :xml)
           stub_request(:get, 'http://test.com/redirect')
-            .and_return(
+            .to_return(
               status: [300, 'REDIRECT'],
               headers: { location: "http://api.foo.com/v2" }
             )
           stub_request(:get, 'http://api.foo.com/v2')
-            .and_return(
+            .to_return(
               status: [300, 'REDIRECT'],
               headers: { location: '/v3' }
             )
           stub_request(:get, 'http://api.foo.com/v3')
-            .and_return(body: '<hash><foo>bar</foo></hash>')
+            .to_return(body: '<hash><foo>bar</foo></hash>')
           response = @request.perform
           expect(response.request.base_uri.to_s).to eq("http://api.foo.com")
           expect(response.request.path.to_s).to eq("/v3")
@@ -621,7 +621,7 @@ RSpec.describe HTTParty::Request do
         it "raises an error if redirect has duplicate location header" do
           @request = HTTParty::Request.new(Net::HTTP::Get, 'http://test.com/redirect', format: :xml)
           stub_request(:get, 'http://test.com/redirect')
-            .and_return(
+            .to_return(
               status: [300, 'REDIRECT'],
               headers: {
                 location: ['http://api.foo.com/v2', 'http://api.foo.com/v2']
@@ -637,12 +637,12 @@ RSpec.describe HTTParty::Request do
 
         it "redirects including port" do
           stub_request(:get, 'http://withport.com:3000/v1')
-            .and_return(
+            .to_return(
               status: [301, 'Moved Permanently'],
               headers: { location: 'http://withport.com:3000/v2' }
             )
           stub_request(:get, 'http://withport.com:3000/v2')
-            .and_return(status: 200)
+            .to_return(status: 200)
           request = HTTParty::Request.new(Net::HTTP::Get, 'http://withport.com:3000/v1')
           response = request.perform
           expect(response.request.base_uri.to_s).to eq("http://withport.com:3000")

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -160,32 +160,34 @@ RSpec.describe HTTParty::Request do
     context 'digest_auth' do
       before do
         response_sequence = [
-          {status: ['401', 'Unauthorized' ], headers: {
-            www_authenticate: 'Digest realm="Log Viewer", qop="auth", nonce="2CA0EC6B0E126C4800E56BA0C0003D3C", opaque="5ccc069c403ebaf9f0171e9517f40e41", stale=false',
-            set_cookie: 'custom-cookie=1234567',
+          {
+            status: ['401', 'Unauthorized' ], headers: {
+              www_authenticate: 'Digest realm="Log Viewer", qop="auth", nonce="2CA0EC6B0E126C4800E56BA0C0003D3C", opaque="5ccc069c403ebaf9f0171e9517f40e41", stale=false',
+              set_cookie: 'custom-cookie=1234567'
             }
           },
-          {status: ['200', 'OK']}
+          { status: ['200', 'OK'] }
         ]
-        stub_request(:get, "http://api.foo.com/v1").and_return(response_sequence)
+        stub_request(:get, 'http://api.foo.com/v1').and_return(response_sequence)
       end
 
       it 'should not send credentials more than once' do
         response_sequence = [
-          {status: ['401', 'Unauthorized' ], headers: {
-            www_authenticate: 'Digest realm="Log Viewer", qop="auth", nonce="2CA0EC6B0E126C4800E56BA0C0003D3C", opaque="5ccc069c403ebaf9f0171e9517f40e41", stale=false',
-            set_cookie: 'custom-cookie=1234567'
+          {
+            status: ['401', 'Unauthorized' ], headers: {
+              www_authenticate: 'Digest realm="Log Viewer", qop="auth", nonce="2CA0EC6B0E126C4800E56BA0C0003D3C", opaque="5ccc069c403ebaf9f0171e9517f40e41", stale=false',
+              set_cookie: 'custom-cookie=1234567'
             }
           },
-          {status: ['401', 'Unauthorized' ], headers: {
-            www_authenticate: 'Digest realm="Log Viewer", qop="auth", nonce="2CA0EC6B0E126C4800E56BA0C0003D3C", opaque="5ccc069c403ebaf9f0171e9517f40e41", stale=false',
-            set_cookie: 'custom-cookie=1234567'
+          {
+            status: ['401', 'Unauthorized' ], headers: {
+              www_authenticate: 'Digest realm="Log Viewer", qop="auth", nonce="2CA0EC6B0E126C4800E56BA0C0003D3C", opaque="5ccc069c403ebaf9f0171e9517f40e41", stale=false',
+              set_cookie: 'custom-cookie=1234567'
             }
           },
-          {status: ['404', 'Not found']}
+          { status: ['404', 'Not found'] }
         ]
-        stub_request(:get, "http://api.foo.com/v1").and_return(
-                            response_sequence)
+        stub_request(:get, 'http://api.foo.com/v1').and_return(response_sequence)
 
         @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}
         response = @request.perform { |v| }
@@ -196,7 +198,7 @@ RSpec.describe HTTParty::Request do
       end
 
       it 'should not be used when configured and the response is 200' do
-        stub_request(:get, "http://api.foo.com/v1").and_return(status: 200)
+        stub_request(:get, 'http://api.foo.com/v1').and_return(status: 200)
         @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}
         response = @request.perform { |v| }
         expect(response.code).to eq(200)
@@ -244,7 +246,7 @@ RSpec.describe HTTParty::Request do
     end
 
     it 'should normalize base uri when specified as request option' do
-      stub_request(:get, 'http://foo.com/resource').to_return(:body => 'Bar')
+      stub_request(:get, 'http://foo.com/resource').to_return(body: 'Bar')
       response = HTTParty.get('/resource', {
         base_uri: 'foo.com'
       })
@@ -569,8 +571,13 @@ RSpec.describe HTTParty::Request do
 
         it "calls block given to perform with each redirect" do
           @request = HTTParty::Request.new(Net::HTTP::Get, 'http://test.com/redirect', format: :xml)
-          stub_request(:get, "http://test.com/redirect").and_return(status: [300, "REDIRECT"], headers: { location: "http://api.foo.com/v2" })
-          stub_request(:get, "http://api.foo.com/v2").and_return(body: "<hash><foo>bar</foo></hash>")
+          stub_request(:get, 'http://test.com/redirect')
+            .and_return(
+              status: [300, 'REDIRECT'],
+              headers: { location: 'http://api.foo.com/v2' }
+            )
+          stub_request(:get, 'http://api.foo.com/v2')
+            .and_return(body: '<hash><foo>bar</foo></hash>')
           body = ""
           response = @request.perform { |chunk| body += chunk }
           expect(body.length).to eq(27)
@@ -591,9 +598,18 @@ RSpec.describe HTTParty::Request do
 
         it "handles multiple redirects and relative location headers on different hosts" do
           @request = HTTParty::Request.new(Net::HTTP::Get, 'http://test.com/redirect', format: :xml)
-          stub_request(:get, "http://test.com/redirect").and_return(status: [300, "REDIRECT"], headers: { location: "http://api.foo.com/v2" })
-          stub_request(:get, "http://api.foo.com/v2").and_return(status: [300, "REDIRECT"], headers: { location: "/v3" })
-          stub_request(:get, "http://api.foo.com/v3").and_return(body: "<hash><foo>bar</foo></hash>")
+          stub_request(:get, 'http://test.com/redirect')
+            .and_return(
+              status: [300, 'REDIRECT'],
+              headers: { location: "http://api.foo.com/v2" }
+            )
+          stub_request(:get, 'http://api.foo.com/v2')
+            .and_return(
+              status: [300, 'REDIRECT'],
+              headers: { location: '/v3' }
+            )
+          stub_request(:get, 'http://api.foo.com/v3')
+            .and_return(body: '<hash><foo>bar</foo></hash>')
           response = @request.perform
           expect(response.request.base_uri.to_s).to eq("http://api.foo.com")
           expect(response.request.path.to_s).to eq("/v3")
@@ -604,7 +620,13 @@ RSpec.describe HTTParty::Request do
 
         it "raises an error if redirect has duplicate location header" do
           @request = HTTParty::Request.new(Net::HTTP::Get, 'http://test.com/redirect', format: :xml)
-          stub_request(:get, "http://test.com/redirect").and_return(status: [300, "REDIRECT"], headers: { location: ["http://api.foo.com/v2","http://api.foo.com/v2"] })
+          stub_request(:get, 'http://test.com/redirect')
+            .and_return(
+              status: [300, 'REDIRECT'],
+              headers: {
+                location: ['http://api.foo.com/v2', 'http://api.foo.com/v2']
+              }
+            )
           expect {@request.perform}.to raise_error(HTTParty::DuplicateLocationHeader)
         end
 
@@ -614,8 +636,13 @@ RSpec.describe HTTParty::Request do
         end
 
         it "redirects including port" do
-          stub_request(:get, "http://withport.com:3000/v1").and_return(status: [301, "Moved Permanently"], headers: { location: "http://withport.com:3000/v2" })
-          stub_request(:get, "http://withport.com:3000/v2").and_return(status: 200)
+          stub_request(:get, 'http://withport.com:3000/v1')
+            .and_return(
+              status: [301, 'Moved Permanently'],
+              headers: { location: 'http://withport.com:3000/v2' }
+            )
+          stub_request(:get, 'http://withport.com:3000/v2')
+            .and_return(status: 200)
           request = HTTParty::Request.new(Net::HTTP::Get, 'http://withport.com:3000/v1')
           response = request.perform
           expect(response.request.base_uri.to_s).to eq("http://withport.com:3000")

--- a/spec/httparty/ssl_spec.rb
+++ b/spec/httparty/ssl_spec.rb
@@ -3,11 +3,11 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
 RSpec.describe HTTParty::Request do
   context "SSL certificate verification" do
     before do
-      FakeWeb.allow_net_connect = true
+      WebMock.allow_net_connect!
     end
 
     after do
-      FakeWeb.allow_net_connect = false
+      WebMock.disable_net_connect!
     end
 
     it "should fail when no trusted CA list is specified, by default" do

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -334,7 +334,7 @@ RSpec.describe HTTParty do
     it "should be able parse response with custom parser" do
       @klass.parser parser
       stub_request(:get, 'http://twitter.com/statuses/public_timeline.xml')
-        .and_return(body: 'tweets')
+        .to_return(body: 'tweets')
       custom_parsed_response = @klass.get('http://twitter.com/statuses/public_timeline.xml')
       expect(custom_parsed_response[:sexy]).to eq(true)
     end
@@ -389,7 +389,7 @@ RSpec.describe HTTParty do
 
     it "should process a request with a uri instance parsed from the uri_adapter" do
       uri = 'http://foo.com/bar'
-      stub_request(:get, uri).and_return(body: 'stuff')
+      stub_request(:get, uri).to_return(body: 'stuff')
       @klass.uri_adapter uri_adapter
       expect(@klass.get(uri).parsed_response).to eq('stuff')
     end
@@ -422,7 +422,7 @@ RSpec.describe HTTParty do
         expect(o[:connection_adapter_options]).to eq(connection_adapter_options)
         HTTParty::ConnectionAdapter.call(u, o)
       }.with(URI.parse(uri), kind_of(Hash))
-      stub_request(:get, uri).and_return(body: 'stuff')
+      stub_request(:get, uri).to_return(body: 'stuff')
       @klass.connection_adapter connection_adapter, connection_adapter_options
       expect(@klass.get(uri).parsed_response).to eq('stuff')
     end
@@ -862,7 +862,7 @@ RSpec.describe HTTParty do
 
     it "should accept webcal URIs" do
       uri = 'http://google.com/'
-      stub_request(:get, uri).and_return(body: 'stuff')
+      stub_request(:get, uri).to_return(body: 'stuff')
       uri = 'webcal://google.com/'
       expect do
         HTTParty.get(uri)

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -333,7 +333,8 @@ RSpec.describe HTTParty do
 
     it "should be able parse response with custom parser" do
       @klass.parser parser
-      stub_request(:get, 'http://twitter.com/statuses/public_timeline.xml').and_return(body: 'tweets')
+      stub_request(:get, 'http://twitter.com/statuses/public_timeline.xml')
+        .and_return(body: 'tweets')
       custom_parsed_response = @klass.get('http://twitter.com/statuses/public_timeline.xml')
       expect(custom_parsed_response[:sexy]).to eq(true)
     end

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -333,7 +333,7 @@ RSpec.describe HTTParty do
 
     it "should be able parse response with custom parser" do
       @klass.parser parser
-      FakeWeb.register_uri(:get, 'http://twitter.com/statuses/public_timeline.xml', body: 'tweets')
+      stub_request(:get, 'http://twitter.com/statuses/public_timeline.xml').and_return(body: 'tweets')
       custom_parsed_response = @klass.get('http://twitter.com/statuses/public_timeline.xml')
       expect(custom_parsed_response[:sexy]).to eq(true)
     end
@@ -388,7 +388,7 @@ RSpec.describe HTTParty do
 
     it "should process a request with a uri instance parsed from the uri_adapter" do
       uri = 'http://foo.com/bar'
-      FakeWeb.register_uri(:get, uri, body: 'stuff')
+      stub_request(:get, uri).and_return(body: 'stuff')
       @klass.uri_adapter uri_adapter
       expect(@klass.get(uri).parsed_response).to eq('stuff')
     end
@@ -421,7 +421,7 @@ RSpec.describe HTTParty do
         expect(o[:connection_adapter_options]).to eq(connection_adapter_options)
         HTTParty::ConnectionAdapter.call(u, o)
       }.with(URI.parse(uri), kind_of(Hash))
-      FakeWeb.register_uri(:get, uri, body: 'stuff')
+      stub_request(:get, uri).and_return(body: 'stuff')
       @klass.connection_adapter connection_adapter, connection_adapter_options
       expect(@klass.get(uri).parsed_response).to eq('stuff')
     end
@@ -861,7 +861,7 @@ RSpec.describe HTTParty do
 
     it "should accept webcal URIs" do
       uri = 'http://google.com/'
-      FakeWeb.register_uri(:get, uri, body: 'stuff')
+      stub_request(:get, uri).and_return(body: 'stuff')
       uri = 'webcal://google.com/'
       expect do
         HTTParty.get(uri)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require "simplecov"
 SimpleCov.start
 
 require "httparty"
-require "fakeweb"
+require 'webmock/rspec'
 
 def file_fixture(filename)
   open(File.join(File.dirname(__FILE__), 'fixtures', "#{filename}")).read
@@ -13,14 +13,6 @@ Dir[File.expand_path(File.join(File.dirname(__FILE__), 'support', '**', '*.rb'))
 RSpec.configure do |config|
   config.include HTTParty::StubResponse
   config.include HTTParty::SSLTestHelper
-
-  config.before(:suite) do
-    FakeWeb.allow_net_connect = false
-  end
-
-  config.after(:suite) do
-    FakeWeb.allow_net_connect = true
-  end
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
Fakeweb hasn't had a release in years and sadly no longer appears to be maintained. As a result tests are failing on more modern Rubies (2.4.x). This change replaces Fakeweb with Webmock, which is actively maintained, making tests green on all supported Rubies.

Fixes https://github.com/jnunemaker/httparty/issues/510 and https://github.com/jnunemaker/httparty/issues/524