### PR TITLE
Give some spacing love to code snippets in docs/README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,11 +24,10 @@ You can use this guide to work with SSL certificates.
 # Use this example if you are using a pem file
 
 class Client
-	include HTTParty
-	
-	base_uri "https://example.com"
-	pem File.read("#{File.expand_path('.')}/path/to/certs/cert.pem"), "123456"
+  include HTTParty
 
+  base_uri "https://example.com"
+  pem File.read("#{File.expand_path('.')}/path/to/certs/cert.pem"), "123456"
 end
 ```
 
@@ -38,11 +37,10 @@ end
 # Use this example if you are using a pkcs12 file
 
 class Client
-	include HTTParty
-	
-	base_uri "https://example.com"
-	pkcs12 File.read("#{File.expand_path('.')}/path/to/certs/cert.p12"), "123456"
+  include HTTParty
 
+  base_uri "https://example.com"
+  pkcs12 File.read("#{File.expand_path('.')}/path/to/certs/cert.p12"), "123456"
 end
 ```
 
@@ -52,11 +50,10 @@ end
 # Use this example if you are using a pkcs12 file
 
 class Client
-	include HTTParty
-	
-	base_uri "https://example.com"
-	ssl_ca_file "#{File.expand_path('.')}/path/to/certs/cert.pem"
+  include HTTParty
 
+  base_uri "https://example.com"
+  ssl_ca_file "#{File.expand_path('.')}/path/to/certs/cert.pem"
 end
 ```
 
@@ -66,10 +63,10 @@ end
 # Use this example if you are using a pkcs12 file
 
 class Client
-	include HTTParty
-	
-	base_uri "https://example.com"
- 	ssl_ca_path '/path/to/certs'
+  include HTTParty
+
+  base_uri "https://example.com"
+  ssl_ca_path '/path/to/certs'
 end
 ```
 
@@ -77,13 +74,13 @@ You can also include this options with the call:
 
 ```ruby
 class Client
-	include HTTParty
-	
-	base_uri "https://example.com"
-	
-	def	self.fetch
-		get("/resources", pem: (File.read("#{File.expand_path('.')}/path/to/certs/cert.pem"), "123456")
-	end
+  include HTTParty
+
+  base_uri "https://example.com"
+
+  def self.fetch
+    get("/resources", pem: (File.read("#{File.expand_path('.')}/path/to/certs/cert.pem"), "123456")
+  end
 end
 ```
 
@@ -92,18 +89,18 @@ end
 In some cases you may want to skip SSL verification, because the entity that issue the certificate is not a valid one, but you still want to work with it. You can achieve this through:
 
 ```ruby
-#Skips SSL certificate verification
+# Skips SSL certificate verification
 
 class Client
-	include HTTParty
+  include HTTParty
 
-	base_uri "https://example.com"
-	pem File.read("#{File.expand_path('.')}/path/to/certs/cert.pem"), "123456"
-	
-	def	self.fetch
-		get("/resources", verify: false)
-		# You can also use something like:
-		# get("resources", verify_peer: false)
-	end
+  base_uri "https://example.com"
+  pem File.read("#{File.expand_path('.')}/path/to/certs/cert.pem"), "123456"
+
+  def self.fetch
+    get("/resources", verify: false)
+    # You can also use something like:
+    # get("resources", verify_peer: false)
+  end
 end
 ```


### PR DESCRIPTION
This might be a long shot (and a very minor one too), but while I was checking out some examples in [docs/README](https://github.com/jnunemaker/httparty/blob/master/docs/README.md), I noticed that most of them are not properly indented.

#### Some points to consider:
- The official [README.md](https://github.com/jnunemaker/httparty/blob/master/README.md) uses 2 spaces. This PR is just following the consistency for the docs.
- Might be opinionated, but 2-spaces is already considered as a [community standard](https://github.com/bbatsov/ruby-style-guide#spaces-indentation).
- This will reduce the cognitive load when reading the code
- When copying the code snippets to our favorite editors (probably for those who haven't discovered auto indent), it requires another action for the developer to trim the spaces just to make it consistent with the two spaces code.

#### Before 
![httpartybad](https://user-images.githubusercontent.com/2811885/27324494-fa23fada-55d7-11e7-9fc2-b37b33b4e3a3.gif)

#### After
![httpartygood](https://user-images.githubusercontent.com/2811885/27324500-fd7f957c-55d7-11e7-8738-233288a08331.gif)

Please review. Thanks!