### PR TITLE
capture cookies returned from http_digest setup request

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -240,6 +240,7 @@ module HTTParty
     end
 
     def setup_digest_auth
+      capture_cookies(last_response)
       @raw_request.digest_auth(username, password, last_response)
     end
 

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -226,6 +226,14 @@ RSpec.describe HTTParty::Request do
         expect(raw_request.get_fields('cookie')).to eql ["custom-cookie=1234567"]
       end
 
+      it 'should capture cookies returned from a 401 response' do
+        @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}
+        response = @request.perform {|v|}
+        expect(response.code).to eq(200)
+
+        expect(@request.options[:headers]['Cookie']).to match(/custom-cookie=1234567/)
+      end
+
       it 'should merge cookies from request and a 401 response' do
 
         @request.options[:digest_auth] = {username: 'foobar', password: 'secret'}


### PR DESCRIPTION
This change captures the cookies returned from the original http_digest 401 request, so that they can be used on subsequent requests. The use case here is that the session cookie is only returned on the first request.