### PR TITLE
Add ResponseError response attribute to message

### DIFF
--- a/lib/httparty/exceptions.rb
+++ b/lib/httparty/exceptions.rb
@@ -20,6 +20,7 @@ module HTTParty
     # @param [Net::HTTPResponse]
     def initialize(response)
       @response = response
+      super(response)
     end
   end
 


### PR DESCRIPTION
When I raise a HTTParty::ResponseError, the log message is not very helpful.

# Repro

```rb
raise HTTParty::ResponseError.new(response)
```

# Expected

```
HTTParty::ResponseError: { "status"=>"error", "message"=>"That's not how this works, that's not how any of this works!" }
```

# Actual

```
HTTParty::ResponseError: HTTParty::ResponseError
```

# Resolution

So I added the response to the error message.