### PR TITLE
Deprecates method delegation via method_missing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+## 0.15.7
+
+Change
+
+* [Deprecated method delegation to response](https://github.com/jnunemaker/httparty/pull/550)
+
+## 0.15.6
+
 ## 0.15.5
 
 Fixed


### PR DESCRIPTION
Delegating methods to other objects using method_missing in instances
of HTTParty::Response is causing unexpected behaviour and has resulted
in multiple issues. Work-arounds to specific issues have been
successful but this change starts the process of removing the root
cause.

Discussion at https://github.com/jnunemaker/httparty/issues/381

- The user will receive a deprecation warning when using a method that is delegated.
- To remove the warning they should call the method on `response` or `parsed_response` instead.
- To opt-in to the new behaviour globally the user can call `HTTParty::Response.disable_method_delegation!`

Most of this code is temporary, to facilitate the transition from one set of
behaviours to another. 