### PR TITLE
add ability to parse response from JSONAPI

### DIFF
--- a/lib/httparty/parser.rb
+++ b/lib/httparty/parser.rb
@@ -38,16 +38,17 @@ module HTTParty
   # @abstract Read the Custom Parsers section for more information.
   class Parser
     SupportedFormats = {
-      'text/xml'               => :xml,
-      'application/xml'        => :xml,
-      'application/json'       => :json,
-      'text/json'              => :json,
-      'application/javascript' => :plain,
-      'text/javascript'        => :plain,
-      'text/html'              => :html,
-      'text/plain'             => :plain,
-      'text/csv'               => :csv,
-      'application/csv'        => :csv,
+      'text/xml'                    => :xml,
+      'application/xml'             => :xml,
+      'application/json'            => :json,
+      'application/vnd.api+json'    => :json,
+      'text/json'                   => :json,
+      'application/javascript'      => :plain,
+      'text/javascript'             => :plain,
+      'text/html'                   => :html,
+      'text/plain'                  => :plain,
+      'text/csv'                    => :csv,
+      'application/csv'             => :csv,
       'text/comma-separated-values' => :csv
     }
 

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -373,6 +373,12 @@ RSpec.describe HTTParty::Request do
       end
     end
 
+    it 'should handle application/vnd.api+json' do
+      ["application/vnd.api+json", "application/vnd.api+json; charset=iso8859-1"].each do |ct|
+        expect(@request.send(:format_from_mimetype, ct)).to eq(:json)
+      end
+    end
+
     it 'should handle application/json' do
       ["application/json", "application/json; charset=iso8859-1"].each do |ct|
         expect(@request.send(:format_from_mimetype, ct)).to eq(:json)


### PR DESCRIPTION
JSONAPI is using this content-type `application/vnd.api+json`, so just added it to the parsing list.