### PR TITLE
Silence some noisy spec warnings in Ruby 2.4

### DIFF
--- a/lib/httparty/cookie_hash.rb
+++ b/lib/httparty/cookie_hash.rb
@@ -16,6 +16,6 @@ class HTTParty::CookieHash < Hash #:nodoc:
   end
 
   def to_cookie_string
-    reject { |k, v| CLIENT_COOKIES.include?(k.to_s.downcase) }.collect { |k, v| "#{k}=#{v}" }.join("; ")
+    select { |k, v| !CLIENT_COOKIES.include?(k.to_s.downcase) }.collect { |k, v| "#{k}=#{v}" }.join("; ")
   end
 end

--- a/spec/httparty/response_spec.rb
+++ b/spec/httparty/response_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe HTTParty::Response do
       expect(@response.code).to eq(@response_object.code)
     end
 
-    it "should set code as a Fixnum" do
-      expect(@response.code).to be_an_instance_of(Fixnum)
+    it "should set code as an Integer" do
+      expect(@response.code).to be_a(Integer)
     end
 
     context 'when raise_on is supplied' do


### PR DESCRIPTION
Ruby 2.4 caused the specs to become slightly noisier due to a deprecation warning for `Fixnum` and a warning in Ruby's `reject` (see https://github.com/ruby/ruby/blob/v2_4_1/hash.c#L1335-L1337 ). This PR makes a couple of small tweaks to eliminate the new warnings.