### PR TITLE
add Response#pretty_print | Restore documented behavior

### DIFF
--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -67,6 +67,14 @@ module HTTParty
       end
     end
 
+    def pretty_print(pp)
+      if !parsed_response.nil? && parsed_response.respond_to?(:pretty_print)
+        parsed_response.pretty_print(pp)
+      else
+        super
+      end
+    end
+
     def display(port=$>)
       if !parsed_response.nil? && parsed_response.respond_to?(:display)
         parsed_response.display(port)


### PR DESCRIPTION
As discussed in #567, the changes introduced 5a78a14 resulted in change of
behavior when viewing the Response objects using command line version of the
HTTParty or tools like pry.

This changs adds minimal version of the #pretty_print method that behaves the
same as code before, when response was inheriting from BasicObject rather than
Object. This is because PP::ObjectMixin applies to Object, but it not
BasicObject.

Following this commit, both CLI version of httparty and pry work correctly (as they did initially).