### PR TITLE
Add support for Object#tap to HTTParty::Response

### DIFF
--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -54,6 +54,12 @@ module HTTParty
     if ::RUBY_VERSION >= "2.0.0" && ::RUBY_PLATFORM != "java"
       alias_method :multiple_choice?, :multiple_choices?
     end
+    
+    if ::RUBY_VERSION >= "1.9.0"
+      def tap(&block)
+        ::Object.instance_method(:tap).bind(self).call(&block)
+      end
+    end
 
     def nil?
       response.nil? || response.body.nil? || response.body.empty?


### PR DESCRIPTION
This is more complicated than just writing one myself but I feel this will keep the behaviour consistent across Ruby versions