### PR TITLE
Parse content with application/hal+json content type as JSON

### DIFF
--- a/lib/httparty/parser.rb
+++ b/lib/httparty/parser.rb
@@ -42,6 +42,7 @@ module HTTParty
       'application/xml'             => :xml,
       'application/json'            => :json,
       'application/vnd.api+json'    => :json,
+      'application/hal+json'        => :json,
       'text/json'                   => :json,
       'application/javascript'      => :plain,
       'text/javascript'             => :plain,

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -379,6 +379,12 @@ RSpec.describe HTTParty::Request do
       end
     end
 
+    it 'should handle application/hal+json' do
+      ["application/hal+json", "application/hal+json; charset=iso8859-1"].each do |ct|
+        expect(@request.send(:format_from_mimetype, ct)).to eq(:json)
+      end
+    end
+
     it 'should handle application/json' do
       ["application/json", "application/json; charset=iso8859-1"].each do |ct|
         expect(@request.send(:format_from_mimetype, ct)).to eq(:json)


### PR DESCRIPTION
This change allows the parsing of content with `application/hal+json` content-type (which is just JSON anyway) as JSON when using the `#parsed_response` method.

Currently this content type is ignored and the method returns a String. Since HAL is just JSON with an additional specification for how some metadata should be included it can be parsed as regular JSON.

More on HAL here: http://stateless.co/hal_specification.html

An example of it in the wild in the Stellar Horizon API: https://horizon.stellar.org/