### PR TITLE
Fix multipart uploads with boolean params.

### DIFF
--- a/lib/httparty/request/body.rb
+++ b/lib/httparty/request/body.rb
@@ -36,7 +36,7 @@ module HTTParty
           memo += "\r\n"
           memo += "Content-Type: application/octet-stream\r\n" if file?(value)
           memo += "\r\n"
-          memo += file?(value) ? value.read : value
+          memo += file?(value) ? value.read : value.to_s
           memo += "\r\n"
         end
 

--- a/spec/httparty/request/body_spec.rb
+++ b/spec/httparty/request/body_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe HTTParty::Request::Body do
             user: {
               avatar: File.open('spec/fixtures/tiny.gif'),
               first_name: 'John',
-              last_name: 'Doe'
+              last_name: 'Doe',
+              enabled: true
             }
           }
         end
@@ -45,6 +46,10 @@ RSpec.describe HTTParty::Request::Body do
           "Content-Disposition: form-data; name=\"user[last_name]\"\r\n" \
           "\r\n" \
           "Doe\r\n" \
+          "--------------------------c772861a5109d5ef\r\n" \
+          "Content-Disposition: form-data; name=\"user[enabled]\"\r\n" \
+          "\r\n" \
+          "true\r\n" \
           "--------------------------c772861a5109d5ef--\r\n"
         end
 


### PR DESCRIPTION
I am using a gem ([ocr_space](https://github.com/suyesh/ocr_space)) that [passes a boolean param](https://github.com/suyesh/ocr_space/blob/master/lib/ocr_space/convert.rb#L17) to `HTTParty.post`. This started failing in v0.16 with the following error message:

```ruby
TypeError: no implicit conversion of false into String
from /gems/httparty-0.16.0/lib/httparty/request/body.rb:40:in `+'
```