### PR TITLE
Fix rspec warnings

### DIFF
--- a/spec/httparty/connection_adapter_spec.rb
+++ b/spec/httparty/connection_adapter_spec.rb
@@ -32,9 +32,12 @@ RSpec.describe HTTParty::ConnectionAdapter do
   end
 
   describe ".call" do
+    let(:uri) { URI 'http://www.google.com' }
+    let(:options) { { foo: :bar } }
+
     it "generates an HTTParty::ConnectionAdapter instance with the given uri and options" do
-      expect(HTTParty::ConnectionAdapter).to receive(:new).with(@uri, @options).and_return(double(connection: nil))
-      HTTParty::ConnectionAdapter.call(@uri, @options)
+      expect(HTTParty::ConnectionAdapter).to receive(:new).with(uri, options).and_return(double(connection: nil))
+      HTTParty::ConnectionAdapter.call(uri, options)
     end
 
     it "calls #connection on the connection adapter" do
@@ -42,7 +45,7 @@ RSpec.describe HTTParty::ConnectionAdapter do
       connection = double('Connection')
       expect(adapter).to receive(:connection).and_return(connection)
       allow(HTTParty::ConnectionAdapter).to receive_messages(new: adapter)
-      expect(HTTParty::ConnectionAdapter.call(@uri, @options)).to be connection
+      expect(HTTParty::ConnectionAdapter.call(uri, options)).to be connection
     end
   end
 

--- a/spec/httparty/net_digest_auth_spec.rb
+++ b/spec/httparty/net_digest_auth_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe Net::HTTPHeader::DigestAuthenticator do
         include Net::HTTPHeader
         def initialize
           @header = {}
+          @path = '/'
+          @method = 'GET'
         end
       end).new
     } 

--- a/spec/httparty/parser_spec.rb
+++ b/spec/httparty/parser_spec.rb
@@ -27,10 +27,10 @@ RSpec.describe HTTParty::Parser do
     end
 
     it "returns the SupportedFormats constant for subclasses" do
-      class MyParser < HTTParty::Parser
-        SupportedFormats = {"application/atom+xml" => :atom}
-      end
-      expect(MyParser.formats).to eq({"application/atom+xml" => :atom})
+      klass = Class.new(HTTParty::Parser)
+      klass::SupportedFormats = { "application/atom+xml" => :atom }
+
+      expect(klass.formats).to eq({"application/atom+xml" => :atom})
     end
   end
 

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -591,7 +591,7 @@ RSpec.describe HTTParty::Request do
           stub_request(:get, 'http://api.foo.com/v2')
             .to_return(body: '<hash><foo>bar</foo></hash>')
           body = ""
-          response = @request.perform { |chunk| body += chunk }
+          @request.perform { |chunk| body += chunk }
           expect(body.length).to eq(27)
         end
 

--- a/spec/httparty/response_spec.rb
+++ b/spec/httparty/response_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe HTTParty::Response do
         subject { described_class.new(request, @response_object, @parsed_response) }
 
         it 'does not throw exception' do
-          expect{ subject }.not_to raise_error(HTTParty::ResponseError)
+          expect{ subject }.not_to raise_error
         end
       end
     end

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -358,11 +358,12 @@ RSpec.describe HTTParty do
 
     it "raises UnsupportedFormat when the parser cannot handle the format" do
       @klass.format :json
-      class MyParser < HTTParty::Parser
-        SupportedFormats = {}
-      end unless defined?(MyParser)
+
+      parser_class = Class.new(HTTParty::Parser)
+      parser_class::SupportedFormats = {}
+
       expect do
-        @klass.parser MyParser
+        @klass.parser parser_class
       end.to raise_error(HTTParty::UnsupportedFormat)
     end
 


### PR DESCRIPTION
This change cleans up some of the warnings output when running test suite.

- Removes the redefining of `MyParser` class in individual tests.
- Instantiates all variables that are used while tests are running with sensible defaults (they're actually fine to be `nil`, so long as they're defined).
- Removes a specific error check that could create false positives.

An error with the SSLTestServer support object related to unknown CAs isn't fixed by this.