### PR TITLE
Correctly handle nested params

### DIFF
--- a/lib/httparty/hash_conversions.rb
+++ b/lib/httparty/hash_conversions.rb
@@ -26,7 +26,7 @@ module HTTParty
     def self.normalize_param(key, value)
       normalized_keys = normalize_keys(key, value)
 
-      normalized_keys.inject('') do |string, (k, v)|
+      normalized_keys.flatten.each_slice(2).inject('') do |string, (k, v)|
         string + "#{k}=#{ERB::Util.url_encode(v.to_s)}&"
       end
     end

--- a/spec/httparty/hash_conversions_spec.rb
+++ b/spec/httparty/hash_conversions_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe HTTParty::HashConversions do
       }
       expect(HTTParty::HashConversions.to_params(hash)).to eq("name=bob&address[street]=111%20ruby%20ave.&address[city]=ruby%20central&address[phones][]=111-111-1111&address[phones][]=222-222-2222")
     end
+
+    context "nested params" do
+      it 'creates a params string from a hash' do
+        hash = { marketing_event: { marketed_resources: [ {type:"product", id: 57474842640 } ] } }
+        expect(HTTParty::HashConversions.to_params(hash)).to eq("marketing_event[marketed_resources][][type]=product&marketing_event[marketed_resources][][id]=57474842640")
+      end
+    end
   end
 
   describe ".normalize_param" do


### PR DESCRIPTION
Had the same problem as was mentioned in Issue #574. 

The normalize_param expected an array structure of
``` [ [key_a, value_a], [key_b, value_b] ]```

However when recursing you would get structure like this, 
```[ [key_a, value_a, key_b, value_b] ]```