### PR TITLE
Support ActionDispatch::Http::UploadedFile again

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Support ActionDispatch::Http::UploadedFile again](https://github.com/jnunemaker/httparty/pull/585)
+
 ## 0.16.1
 
 * [Parse content with application/hal+json content type as JSON](https://github.com/jnunemaker/httparty/pull/573)

--- a/lib/httparty/request/body.rb
+++ b/lib/httparty/request/body.rb
@@ -32,7 +32,7 @@ module HTTParty
         multipart = normalized_params.inject('') do |memo, (key, value)|
           memo += "--#{boundary}\r\n"
           memo += %(Content-Disposition: form-data; name="#{key}")
-          memo += %(; filename="#{File.basename(value)}") if file?(value)
+          memo += %(; filename="#{File.basename(value.path)}") if file?(value)
           memo += "\r\n"
           memo += "Content-Type: application/octet-stream\r\n" if file?(value)
           memo += "\r\n"


### PR DESCRIPTION
Using the `path` method instead of passing the file directly to `File.basename` ensures that `ActionDispatch::Http::UploadedFile` can be used again.

Related issue: https://github.com/jnunemaker/httparty/issues/584

Note: ActionDispatch isn't a dependency of the library, so I opted not to write a test specifically for it. I tried to account for it in the existing tests by checking that e.g. `to_str` isn't called on the file object, but that didn't work since `File.basename` is implemented in C.