### PR TITLE
stream_body fragment include http_response feature

### DIFF
--- a/examples/stream_download.rb
+++ b/examples/stream_download.rb
@@ -9,8 +9,14 @@ url = "https://cdn.kernel.org/pub/linux/kernel/v4.x/#{filename}"
 
 File.open(filename, "w") do |file|
   response = HTTParty.get(url, stream_body: true) do |fragment|
-    print "."
-    file.write(fragment)
+    if [301, 302].include?(fragment.code)
+      print "skip writing for redirect"
+    elsif fragment.code == 200
+      print "."
+      file.write(fragment)
+    else
+      raise StandardError, "Non-success status code while streaming #{fragment.code}"
+    end
   end
 end
 puts

--- a/lib/httparty/fragment_with_response.rb
+++ b/lib/httparty/fragment_with_response.rb
@@ -1,0 +1,18 @@
+require 'delegate'
+
+module HTTParty
+  # Allow access to http_response and code by delegation on fragment
+  class FragmentWithResponse < SimpleDelegator
+    extend Forwardable
+
+    def_delegator :@http_response, :code
+
+    attr_reader :http_response
+
+    def initialize(fragment, http_response)
+      @fragment = fragment
+      @http_response = http_response
+      super fragment
+    end
+  end
+end

--- a/lib/httparty/fragment_with_response.rb
+++ b/lib/httparty/fragment_with_response.rb
@@ -5,9 +5,11 @@ module HTTParty
   class FragmentWithResponse < SimpleDelegator
     extend Forwardable
 
-    def_delegator :@http_response, :code
-
     attr_reader :http_response
+
+    def code
+      @http_response.code.to_i
+    end
 
     def initialize(fragment, http_response)
       @fragment = fragment

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -1,5 +1,6 @@
 require 'erb'
 require 'httparty/request/body'
+require 'httparty/fragment_with_response'
 
 module HTTParty
   class Request #:nodoc:
@@ -146,7 +147,7 @@ module HTTParty
 
           http_response.read_body do |fragment|
             chunks << fragment unless options[:stream_body]
-            block.call(fragment)
+            block.call FragmentWithResponse.new(fragment, http_response)
           end
 
           chunked_body = chunks.join

--- a/spec/httparty/fragment_with_response_spec.rb
+++ b/spec/httparty/fragment_with_response_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe HTTParty::FragmentWithResponse do
     expect(fragment).to eq("chunk")
   end
   it "has access to delegators" do
-    response = double(code: 200)
+    response = double(code: '200')
     fragment = HTTParty::FragmentWithResponse.new("chunk", response)
     expect(fragment.code).to eq(200)
     expect(fragment.http_response).to eq response

--- a/spec/httparty/fragment_with_response_spec.rb
+++ b/spec/httparty/fragment_with_response_spec.rb
@@ -1,0 +1,14 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '../spec_helper'))
+
+RSpec.describe HTTParty::FragmentWithResponse do
+  it "access to fragment" do
+    fragment = HTTParty::FragmentWithResponse.new("chunk", nil)
+    expect(fragment).to eq("chunk")
+  end
+  it "has access to delegators" do
+    response = double(code: 200)
+    fragment = HTTParty::FragmentWithResponse.new("chunk", response)
+    expect(fragment.code).to eq(200)
+    expect(fragment.http_response).to eq response
+  end
+end

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -806,6 +806,8 @@ RSpec.describe HTTParty do
       expect(
         HTTParty.get('http://www.google.com', options) do |fragment|
           expect(chunks).to include(fragment)
+          expect(fragment.code).to eql 200
+          expect(fragment.http_response).to be
         end.parsed_response
       ).to eq(nil)
     end


### PR DESCRIPTION
Add a `:stream_body_include_response_code` option to get a response code back with the fragment when streaming data. This allows for skipping redirects while streaming (and other error detection), which before would tack the redirect onto the file.

We needed this, I appreciate any suggestions.