### PR TITLE
Add frozen_string_literal everywhere and fix string mutation with force_encoding

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,6 +66,11 @@ Style/RegexpLiteral:
 Style/NumericLiterals:
   MinDigits: 6
 
+# Offense count: 0
+# Cop supports --auto-correct.
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: always
+
 # Offense count: 4
 # Cop supports --auto-correct.
 Lint/UnusedMethodArgument:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 gemspec
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:spec)

--- a/bin/httparty
+++ b/bin/httparty
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+# frozen_string_literal: true
+
 require "optparse"
 require "pp"
 

--- a/examples/aaws.rb
+++ b/examples/aaws.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'active_support'
 

--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 dir = File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
 require File.join(dir, 'httparty')
 require 'pp'

--- a/examples/crack.rb
+++ b/examples/crack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'crack'
 

--- a/examples/custom_parsers.rb
+++ b/examples/custom_parsers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 dir = File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
 require File.join(dir, 'httparty')
 require 'pp'

--- a/examples/delicious.rb
+++ b/examples/delicious.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 dir = File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
 require File.join(dir, 'httparty')
 require 'pp'

--- a/examples/google.rb
+++ b/examples/google.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 dir = File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
 require File.join(dir, 'httparty')
 require 'pp'

--- a/examples/headers_and_user_agents.rb
+++ b/examples/headers_and_user_agents.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # To send custom user agents to identify your application to a web service (or mask as a specific browser for testing), send "User-Agent" as a hash to headers as shown below.
 
 dir = File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))

--- a/examples/logging.rb
+++ b/examples/logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 dir = File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
 require File.join(dir, 'httparty')
 require 'logger'

--- a/examples/nokogiri_html_parser.rb
+++ b/examples/nokogiri_html_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'nokogiri'
 

--- a/examples/rescue_json.rb
+++ b/examples/rescue_json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 dir = File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
 require File.join(dir, 'httparty')
 

--- a/examples/rubyurl.rb
+++ b/examples/rubyurl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 dir = File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
 require File.join(dir, 'httparty')
 require 'pp'

--- a/examples/stackexchange.rb
+++ b/examples/stackexchange.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 dir = File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
 require File.join(dir, 'httparty')
 require 'pp'

--- a/examples/stream_download.rb
+++ b/examples/stream_download.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 dir = File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
 require File.join(dir, 'httparty')
 require 'pp'

--- a/examples/tripit_sign_in.rb
+++ b/examples/tripit_sign_in.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 dir = File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
 require File.join(dir, 'httparty')
 

--- a/examples/twitter.rb
+++ b/examples/twitter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 dir = File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
 require File.join(dir, 'httparty')
 require 'pp'

--- a/examples/whoismyrep.rb
+++ b/examples/whoismyrep.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 dir = File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
 require File.join(dir, 'httparty')
 require 'pp'

--- a/features/steps/env.rb
+++ b/features/steps/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'mongrel'
 require './lib/httparty'
 require 'rspec/expectations'

--- a/features/steps/httparty_response_steps.rb
+++ b/features/steps/httparty_response_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Not needed anymore in ruby 2.0, but needed to resolve constants
 # in nested namespaces. This is taken from rails :)
 def constantize(camel_cased_word)

--- a/features/steps/httparty_steps.rb
+++ b/features/steps/httparty_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 When /^I set my HTTParty timeout option to (\d+)$/ do |timeout|
   @request_options[:timeout] = timeout.to_i
 end

--- a/features/steps/mongrel_helper.rb
+++ b/features/steps/mongrel_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 class BasicMongrelHandler < Mongrel::HttpHandler
   attr_accessor :content_type, :custom_headers, :response_body, :response_code, :preprocessor, :username, :password
@@ -95,7 +97,7 @@ module DigestAuthenticationUsingMD5Sess
   def self.extended(base)
     base.custom_headers["WWW-Authenticate"] = %(Digest realm="#{REALM}",qop="#{QOP}",algorithm="MD5-sess",nonce="#{NONCE}",opaque="opaque"')
   end
-  
+
   def process(request, response)
     if authorized?(request)
       super
@@ -103,11 +105,11 @@ module DigestAuthenticationUsingMD5Sess
       reply_with(response, 401, "Incorrect.  You have 20 seconds to comply.")
     end
   end
-  
+
   def md5(str)
     Digest::MD5.hexdigest(str)
   end
-  
+
   def authorized?(request)
     auth = request.params["HTTP_AUTHORIZATION"]
     params = {}

--- a/features/steps/remote_service_steps.rb
+++ b/features/steps/remote_service_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given /a remote service that returns '(.*)'/ do |response_body|
   @handler = BasicMongrelHandler.new
   step "the response from the service has a body of '#{response_body}'"

--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'net/http'
 require 'net/https'

--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HTTParty
   # Default connection adapter that returns a new Net::HTTP each time
   #
@@ -38,12 +40,12 @@ module HTTParty
   # in the #options attribute. It is up to you to interpret them within your
   # connection adapter. Take a look at the implementation of
   # HTTParty::ConnectionAdapter#connection for examples of how they are used.
-  # The keys used in options are 
+  # The keys used in options are
   # * :+timeout+: timeout in seconds
   # * :+open_timeout+: http connection open_timeout in seconds, overrides timeout if set
   # * :+read_timeout+: http connection read_timeout in seconds, overrides timeout if set
   # * :+debug_output+: see HTTParty::ClassMethods.debug_output.
-  # * :+cert_store+: contains certificate data. see method 'attach_ssl_certificates' 
+  # * :+cert_store+: contains certificate data. see method 'attach_ssl_certificates'
   # * :+pem+: contains pem client certificate data. see method 'attach_ssl_certificates'
   # * :+p12+: contains PKCS12 client client certificate data.  see method 'attach_ssl_certificates'
   # * :+verify+: verify the server’s certificate against the ca certificate.

--- a/lib/httparty/cookie_hash.rb
+++ b/lib/httparty/cookie_hash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class HTTParty::CookieHash < Hash #:nodoc:
   CLIENT_COOKIES = %w(path expires domain path secure httponly)
 

--- a/lib/httparty/exceptions.rb
+++ b/lib/httparty/exceptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HTTParty
   # @abstact Exceptions raised by HTTParty inherit from Error
   class Error < StandardError; end

--- a/lib/httparty/hash_conversions.rb
+++ b/lib/httparty/hash_conversions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'erb'
 
 module HTTParty

--- a/lib/httparty/logger/apache_formatter.rb
+++ b/lib/httparty/logger/apache_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HTTParty
   module Logger
     class ApacheFormatter #:nodoc:

--- a/lib/httparty/logger/curl_formatter.rb
+++ b/lib/httparty/logger/curl_formatter.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module HTTParty
   module Logger
     class CurlFormatter #:nodoc:
       TAG_NAME = HTTParty.name
-      OUT      = '>'.freeze
-      IN       = '<'.freeze
+      OUT      = '>'
+      IN       = '<'
 
       attr_accessor :level, :logger
 

--- a/lib/httparty/logger/logger.rb
+++ b/lib/httparty/logger/logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'httparty/logger/apache_formatter'
 require 'httparty/logger/curl_formatter'
 

--- a/lib/httparty/module_inheritable_attributes.rb
+++ b/lib/httparty/module_inheritable_attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HTTParty
   module ModuleInheritableAttributes #:nodoc:
     def self.included(base)

--- a/lib/httparty/net_digest_auth.rb
+++ b/lib/httparty/net_digest_auth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'digest/md5'
 require 'net/http'
 
@@ -14,11 +16,11 @@ module Net
 
       authenticator.authorization_header.each do |v|
         add_field('Authorization', v)
-      end 
+      end
 
       authenticator.cookie_header.each do |v|
         add_field('Cookie', v)
-      end      
+      end
     end
 
     class DigestAuthenticator
@@ -113,11 +115,11 @@ module Net
       def algorithm_present?
         @response.key?('algorithm') && !@response['algorithm'].empty?
       end
-      
+
       def use_md5_sess?
         algorithm_present? && @response['algorithm'] == 'MD5-sess'
       end
-      
+
       def a1
         a1_user_realm_pwd =  [@username, @response['realm'], @password].join(':')
         if use_md5_sess?

--- a/lib/httparty/parser.rb
+++ b/lib/httparty/parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HTTParty
   # The default parser used by HTTParty, supports xml, json, html, csv and
   # plain text.
@@ -119,7 +121,7 @@ module HTTParty
       MultiXml.parse(body)
     end
 
-    UTF8_BOM = "\xEF\xBB\xBF".freeze
+    UTF8_BOM = "\xEF\xBB\xBF"
 
     def json
       JSON.parse(body, :quirks_mode => true, :allow_nan => true)

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'erb'
 require 'httparty/request/body'
 

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -288,7 +288,7 @@ module HTTParty
       # NOTE: This will raise an argument error if the
       # charset does not exist
       encoding = Encoding.find(charset)
-      body.force_encoding(encoding.to_s)
+      body.dup.force_encoding(encoding.to_s)
     rescue ArgumentError
       body
     end
@@ -300,16 +300,16 @@ module HTTParty
     def encode_utf_16(body)
       if body.bytesize >= 2
         if body.getbyte(0) == 0xFF && body.getbyte(1) == 0xFE
-          return body.force_encoding("UTF-16LE")
+          return body.dup.force_encoding("UTF-16LE")
         elsif body.getbyte(0) == 0xFE && body.getbyte(1) == 0xFF
-          return body.force_encoding("UTF-16BE")
+          return body.dup.force_encoding("UTF-16BE")
         end
       end
 
       if assume_utf16_is_big_endian
-        body.force_encoding("UTF-16BE")
+        body.dup.force_encoding("UTF-16BE")
       else
-        body.force_encoding("UTF-16LE")
+        body.dup.force_encoding("UTF-16LE")
       end
     end
 

--- a/lib/httparty/request/body.rb
+++ b/lib/httparty/request/body.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'multipart_boundary'
 
 module HTTParty

--- a/lib/httparty/request/multipart_boundary.rb
+++ b/lib/httparty/request/multipart_boundary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'securerandom'
 
 module HTTParty

--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HTTParty
   class Response < Object
     def self.underscore(string)
@@ -59,10 +61,10 @@ module HTTParty
       response.nil? || response.body.nil? || response.body.empty?
     end
 
-    def to_s      
+    def to_s
       if !response.nil? && !response.body.nil? && response.body.respond_to?(:to_s)
         response.body.to_s
-      else 
+      else
         inspect
       end
     end
@@ -80,7 +82,7 @@ module HTTParty
         parsed_response.display(port)
       elsif !response.nil? && !response.body.nil? && response.body.respond_to?(:display)
         response.body.display(port)
-      else 
+      else
         port.write(inspect)
       end
     end
@@ -89,7 +91,7 @@ module HTTParty
       return true if super
       parsed_response.respond_to?(name) || response.respond_to?(name)
     end
-    
+
     protected
 
     def method_missing(name, *args, &block)

--- a/lib/httparty/response/headers.rb
+++ b/lib/httparty/response/headers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'delegate'
 
 module HTTParty
@@ -22,10 +24,10 @@ module HTTParty
       end
 
       def ==(other)
-        if other.is_a?(::Net::HTTPHeader) 
+        if other.is_a?(::Net::HTTPHeader)
           @header == other.instance_variable_get(:@header)
         elsif other.is_a?(Hash)
-          @header == other || @header == Headers.new(other).instance_variable_get(:@header)           
+          @header == other || @header == Headers.new(other).instance_variable_get(:@header)
         end
       end
     end

--- a/lib/httparty/version.rb
+++ b/lib/httparty/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HTTParty
   VERSION = "0.16.2"
 end

--- a/spec/httparty/connection_adapter_spec.rb
+++ b/spec/httparty/connection_adapter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
 
 RSpec.describe HTTParty::ConnectionAdapter do

--- a/spec/httparty/cookie_hash_spec.rb
+++ b/spec/httparty/cookie_hash_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), '../spec_helper'))
 
 RSpec.describe HTTParty::CookieHash do

--- a/spec/httparty/exception_spec.rb
+++ b/spec/httparty/exception_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
 
 RSpec.describe HTTParty::Error do

--- a/spec/httparty/hash_conversions_spec.rb
+++ b/spec/httparty/hash_conversions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe HTTParty::HashConversions do
   describe ".to_params" do
     it "creates a params string from a hash" do

--- a/spec/httparty/logger/apache_formatter_spec.rb
+++ b/spec/httparty/logger/apache_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'spec_helper'))
 
 RSpec.describe HTTParty::Logger::ApacheFormatter do

--- a/spec/httparty/logger/curl_formatter_spec.rb
+++ b/spec/httparty/logger/curl_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'spec_helper'))
 
 RSpec.describe HTTParty::Logger::CurlFormatter do

--- a/spec/httparty/logger/logger_spec.rb
+++ b/spec/httparty/logger/logger_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'spec_helper'))
 
 RSpec.describe HTTParty::Logger do

--- a/spec/httparty/net_digest_auth_spec.rb
+++ b/spec/httparty/net_digest_auth_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
 
 RSpec.describe Net::HTTPHeader::DigestAuthenticator do
@@ -19,7 +21,7 @@ RSpec.describe Net::HTTPHeader::DigestAuthenticator do
 
   context 'Net::HTTPHeader#digest_auth' do
     let(:headers) {
-      (Class.new do 
+      (Class.new do
         include Net::HTTPHeader
         def initialize
           @header = {}
@@ -27,25 +29,25 @@ RSpec.describe Net::HTTPHeader::DigestAuthenticator do
           @method = 'GET'
         end
       end).new
-    } 
+    }
 
     let(:response){
-      (Class.new do 
+      (Class.new do
         include Net::HTTPHeader
         def initialize
           @header = {}
-          self['WWW-Authenticate'] = 
+          self['WWW-Authenticate'] =
           'Digest realm="testrealm@host.com", qop="auth,auth-int", nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", opaque="5ccc069c403ebaf9f0171e9517f40e41"'
         end
       end).new
     }
 
-    it 'should set the authorization header' do 
+    it 'should set the authorization header' do
       expect(headers['authorization']).to be_nil
       headers.digest_auth('user','pass', response)
       expect(headers['authorization']).to_not be_empty
-    end 
-  end 
+    end
+  end
 
   context "with a cookie value in the response header" do
     before do
@@ -228,18 +230,18 @@ RSpec.describe Net::HTTPHeader::DigestAuthenticator do
       expect(authorization_header).to include(%(response="#{request_digest}"))
     end
   end
-  
+
   context "with algorithm specified" do
     before do
       @digest = setup_digest({
                               'www-authenticate' => 'Digest realm="myhost@testrealm.com", nonce="NONCE", qop="auth", algorithm=MD5'
                              })
     end
-    
+
     it "should recognise algorithm was specified" do
       expect( @digest.send :algorithm_present? ).to be(true)
     end
-    
+
     it "should set the algorithm header" do
       expect(authorization_header).to include('algorithm="MD5"')
     end
@@ -251,20 +253,20 @@ RSpec.describe Net::HTTPHeader::DigestAuthenticator do
                               'www-authenticate' => 'Digest realm="myhost@testrealm.com", nonce="NONCE", qop="auth", algorithm=MD5-sess'
                              })
     end
-    
+
     it "should recognise algorithm was specified" do
       expect( @digest.send :algorithm_present? ).to be(true)
     end
-    
+
     it "should set the algorithm header" do
       expect(authorization_header).to include('algorithm="MD5-sess"')
     end
-    
+
     it "should set response using md5-sess algorithm" do
       request_digest = "md5(md5(md5(Mufasa:myhost@testrealm.com:Circle Of Life):NONCE:md5(deadbeef)):NONCE:00000001:md5(deadbeef):auth:md5(GET:/dir/index.html))"
       expect(authorization_header).to include(%(response="#{request_digest}"))
     end
-    
+
   end
-  
+
 end

--- a/spec/httparty/parser_spec.rb
+++ b/spec/httparty/parser_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe HTTParty::Parser do
 
     it "parses ascii 8bit encoding" do
       parser = HTTParty::Parser.new(
-        "{\"currency\":\"\xE2\x82\xAC\"}".force_encoding('ASCII-8BIT'),
+        "{\"currency\":\"\xE2\x82\xAC\"}".dup.force_encoding('ASCII-8BIT'),
         :json
       )
       expect(parser.parse).to eq({"currency" => "€"})

--- a/spec/httparty/parser_spec.rb
+++ b/spec/httparty/parser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
 
 RSpec.describe HTTParty::Parser do

--- a/spec/httparty/request/body_spec.rb
+++ b/spec/httparty/request/body_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 RSpec.describe HTTParty::Request::Body do

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -500,7 +500,7 @@ RSpec.describe HTTParty::Request do
       }
 
       it "should process charset in content type properly" do
-        response = stub_response "Content".force_encoding('ascii-8bit')
+        response = stub_response "Content".dup.force_encoding('ascii-8bit')
         response.initialize_http_header("Content-Type" => "text/plain;charset = utf-8")
         resp = @request.perform
         expect(response_charset).to_not be_empty
@@ -508,7 +508,7 @@ RSpec.describe HTTParty::Request do
       end
 
       it "should process charset in content type properly if it has a different case" do
-        response = stub_response "Content".force_encoding('ascii-8bit')
+        response = stub_response "Content".dup.force_encoding('ascii-8bit')
         response.initialize_http_header("Content-Type" => "text/plain;CHARSET = utf-8")
         resp = @request.perform
         expect(response_charset).to_not be_empty
@@ -516,7 +516,7 @@ RSpec.describe HTTParty::Request do
       end
 
       it "should process quoted charset in content type properly" do
-        response = stub_response "Content".force_encoding('ascii-8bit')
+        response = stub_response "Content".dup.force_encoding('ascii-8bit')
         response.initialize_http_header("Content-Type" => "text/plain;charset = \"utf-8\"")
         resp = @request.perform
         expect(response_charset).to_not be_empty

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
 
 RSpec.describe HTTParty::Request do

--- a/spec/httparty/response_spec.rb
+++ b/spec/httparty/response_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
 
 RSpec.describe HTTParty::Response do
@@ -78,11 +80,11 @@ RSpec.describe HTTParty::Response do
     }.to raise_error(NameError, /HTTParty\:\:Response/)
   end
 
-  it 'does raise an error about itself when invoking a method that does not exist' do 
+  it 'does raise an error about itself when invoking a method that does not exist' do
     expect {
       HTTParty::Response.new(@request_object, @response_object, @parsed_response).qux
     }.to raise_error(NoMethodError, /HTTParty\:\:Response/)
-  end 
+  end
 
   it "returns response headers" do
     response = HTTParty::Response.new(@request_object, @response_object, @parsed_response)
@@ -131,21 +133,21 @@ RSpec.describe HTTParty::Response do
 
   context 'response is array' do
     let(:response_value) { [{'foo' => 'bar'}, {'foo' => 'baz'}] }
-    let(:response) { HTTParty::Response.new(@request_object, @response_object, lambda { response_value }) } 
-    it "should be able to iterate" do 
+    let(:response) { HTTParty::Response.new(@request_object, @response_object, lambda { response_value }) }
+    it "should be able to iterate" do
       expect(response.size).to eq(2)
       expect {
         response.each { |item| }
       }.to_not raise_error
     end
 
-    it 'should respond to array methods' do       
-      expect(response).to respond_to(:bsearch, :compact, :cycle, :delete, :each, :flatten, :flatten!, :compact, :join)    
+    it 'should respond to array methods' do
+      expect(response).to respond_to(:bsearch, :compact, :cycle, :delete, :each, :flatten, :flatten!, :compact, :join)
     end
 
     it 'should equal the string response object body' do
-      expect(response.to_s).to eq(@response_object.body.to_s)    
-    end    
+      expect(response.to_s).to eq(@response_object.body.to_s)
+    end
 
     it 'should display the same as an array' do
       a = StringIO.new
@@ -153,7 +155,7 @@ RSpec.describe HTTParty::Response do
       response_value.display(b)
       response.display(a)
 
-      expect(a.string).to eq(b.string)    
+      expect(a.string).to eq(b.string)
     end
   end
 
@@ -294,27 +296,27 @@ RSpec.describe HTTParty::Response do
 
   describe "headers" do
     let (:empty_headers) { HTTParty::Response::Headers.new }
-    let (:some_headers_hash) do 
+    let (:some_headers_hash) do
       {'Cookie' => 'bob',
       'Content-Encoding' => 'meow'}
-    end 
-    let (:some_headers) do 
+    end
+    let (:some_headers) do
        HTTParty::Response::Headers.new.tap do |h|
          some_headers_hash.each_pair do |k,v|
            h[k] = v
          end
       end
     end
-    it "can initialize without headers" do 
+    it "can initialize without headers" do
       expect(empty_headers).to eq({})
     end
 
     it 'always equals itself' do
-      expect(empty_headers).to eq(empty_headers) 
+      expect(empty_headers).to eq(empty_headers)
       expect(some_headers).to eq(some_headers)
     end
 
-    it 'does not equal itself when not equivalent' do 
+    it 'does not equal itself when not equivalent' do
       expect(empty_headers).to_not eq(some_headers)
     end
 

--- a/spec/httparty/ssl_spec.rb
+++ b/spec/httparty/ssl_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
 
 RSpec.describe HTTParty::Request do

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), 'spec_helper'))
 
 RSpec.describe HTTParty do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "simplecov"
 SimpleCov.start
 

--- a/spec/support/ssl_test_helper.rb
+++ b/spec/support/ssl_test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 module HTTParty

--- a/spec/support/ssl_test_server.rb
+++ b/spec/support/ssl_test_server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 require 'socket'
 require 'thread'

--- a/spec/support/stub_response.rb
+++ b/spec/support/stub_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HTTParty
   module StubResponse
     def stub_http_response_with(filename)


### PR DESCRIPTION
This PR has two commits: 
 1. Add the magic comment `# frozen_string_literal: true` to every file. This will help with migration to ruby 3, where all literals will be frozen. This functionality was added in ruby 2.3.
2. Duplicate strings before calling `force_encoding` in `Request`. String#force_encoding is a mutating function, which will raise a RuntimeError if the response body is a frozen string.

This is mostly causing issues for us with testing using `stub_response` in our application, since we have enabled frozen string literals. 

For example, the following test fails when frozen_string_literals are enabled:
https://github.com/jnunemaker/httparty/blob/da1b1ad1d67be214b0e7a587edf84a4bc5a5e793/spec/httparty/request_spec.rb#L551-L559

The issue also exists with this gem's tests, which you can see by running `git checkout 9c4c7a0 && bundle exec rake`. 

This should not be a breaking change and is being done by other gems as well (e.g. https://github.com/stripe/stripe-ruby/pull/649).

@jnunemaker If you're not interested adding the frozen_string_literal comment everywhere, I'd be happy to pull out `1f29818` as a separate PR as well.