### PR TITLE
gemspec homepage does not exist

### DIFF
--- a/httparty.gemspec
+++ b/httparty.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.licenses    = ['MIT']
   s.authors     = ["John Nunemaker", "Sandro Turriate"]
   s.email       = ["nunemaker@gmail.com"]
-  s.homepage    = "http://jnunemaker.github.com/httparty"
+  s.homepage    = "https://github.com/jnunemaker/httparty"
   s.summary     = 'Makes http fun! Also, makes consuming restful web services dead easy.'
   s.description = 'Makes http fun! Also, makes consuming restful web services dead easy.'
 


### PR DESCRIPTION
this PR points the gemspec homepage at a page that exists - or if the page just got lost somewhere, restoring it would resolve this issue.