### PR TITLE
Fix multipart to set its header even when other headers are provided without overwriting provided content type

### DIFF
--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -352,14 +352,23 @@ RSpec.describe HTTParty::Request do
         expect(headers['content-type']).to match(%r{^multipart/form-data; boundary=---})
       end
 
-      context "and header Content-Type is provided" do
-        it "overwrites the header to: multipart/form-data; boundary=" do
+      context "and header is provided" do
+        it "complete the header with content type as: multipart/form-data; boundary=" do
+          @request.options[:body] = {file: File.open(File::NULL, 'r')}
+          @request.options[:headers] = {"User-Agent" => "HTTParty"}
+          @request.send(:setup_raw_request)
+          headers = @request.instance_variable_get(:@raw_request).each_header.to_a
+          headers = Hash[*headers.flatten]  # Ruby 2.0 doesn't have Array#to_h
+          expect(headers['content-type']).to match(%r{^multipart/form-data; boundary=---})
+        end
+
+        it "does not overwrites provided Content Type" do
           @request.options[:body] = {file: File.open(File::NULL, 'r')}
           @request.options[:headers] = {'Content-Type' => 'application/x-www-form-urlencoded'}
           @request.send(:setup_raw_request)
           headers = @request.instance_variable_get(:@raw_request).each_header.to_a
           headers = Hash[*headers.flatten]  # Ruby 2.0 doesn't have Array#to_h
-          expect(headers['content-type']).to match(%r{^multipart/form-data; boundary=---})
+          expect(headers['content-type']).to match('application/x-www-form-urlencoded')
         end
       end
     end


### PR DESCRIPTION
In regards to issues opened about [Content Type issue with multipart requests](https://github.com/jnunemaker/httparty/issues/595), also mentioned [here](https://github.com/jnunemaker/httparty/pull/569) in comments by @jirutka, there was a [fix implemented](https://github.com/jnunemaker/httparty/pull/576).

I think this fix is incorrect as it prevent any `Content Type` customisation: if the request is multipart, it is always overwritten.
I propose a fix here that allow for `Content Type` customisation, but also makes sure that if we have custom headers but no `Content Type`, the content type is set to `multipart/form-data`. 