### PR TITLE
Unify loggers

### DIFF
--- a/lib/httparty/logger/apache_formatter.rb
+++ b/lib/httparty/logger/apache_formatter.rb
@@ -3,7 +3,7 @@ module HTTParty
     class ApacheFormatter #:nodoc:
       TAG_NAME = HTTParty.name
 
-      attr_accessor :level, :logger, :current_time
+      attr_accessor :level, :logger
 
       def initialize(logger, level)
         @logger = logger
@@ -11,11 +11,34 @@ module HTTParty
       end
 
       def format(request, response)
-        current_time   = Time.now.strftime("%Y-%m-%d %H:%M:%S %z")
-        http_method    = request.http_method.name.split("::").last.upcase
-        path           = request.path.to_s
-        content_length = response.respond_to?(:headers) ? response.headers['Content-Length'] : response['Content-Length']
-        @logger.send @level, "[#{TAG_NAME}] [#{current_time}] #{response.code} \"#{http_method} #{path}\" #{content_length || '-'} "
+        @request = request
+        @response = response
+
+        logger.public_send level, message
+      end
+
+      private
+
+      attr_reader :request, :response
+
+      def message
+        "[#{TAG_NAME}] [#{current_time}] #{response.code} \"#{http_method} #{path}\" #{content_length || '-'} "
+      end
+
+      def current_time
+        Time.now.strftime("%Y-%m-%d %H:%M:%S %z")
+      end
+
+      def http_method
+        request.http_method.name.split("::").last.upcase
+      end
+
+      def path
+        request.path.to_s
+      end
+
+      def content_length
+        response.respond_to?(:headers) ? response.headers['Content-Length'] : response['Content-Length']
       end
     end
   end

--- a/lib/httparty/logger/curl_formatter.rb
+++ b/lib/httparty/logger/curl_formatter.rb
@@ -20,7 +20,7 @@ module HTTParty
         log_request
         log_response
 
-        logger.send level, messages.join("\n")
+        logger.public_send level, messages.join("\n")
       end
 
       private
@@ -80,11 +80,11 @@ module HTTParty
       end
 
       def log(direction, line = '')
-        messages << "[#{TAG_NAME}] [#{time}] #{direction} #{line}"
+        messages << "[#{TAG_NAME}] [#{current_time}] #{direction} #{line}"
       end
 
-      def time
-        @time ||= Time.now.strftime("%Y-%m-%d %H:%M:%S %z")
+      def current_time
+        Time.now.strftime("%Y-%m-%d %H:%M:%S %z")
       end
     end
   end

--- a/spec/httparty/logger/apache_formatter_spec.rb
+++ b/spec/httparty/logger/apache_formatter_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe HTTParty::Logger::ApacheFormatter do
   let(:request_time) { Time.new.strftime("%Y-%m-%d %H:%M:%S %z") }
 
   before do
-    subject.current_time = request_time
     expect(logger_double).to receive(:info).with(log_message)
   end
 


### PR DESCRIPTION
This PR introduces following changes:

1. Use `public_send` instead of `send` for calling logger's public method.
2. Unify naming of a method returing formatted `Time.now` (`current_time` vs `time`).
3. Adjust `ApacheFormatter` to be more similar to `CurlFormatter` (private methods instead of multiple local variables, log message extracted to a dedicated method).

