### PR TITLE
Add Logstash-compatible formatter

### DIFF
--- a/lib/httparty/logger/logger.rb
+++ b/lib/httparty/logger/logger.rb
@@ -1,12 +1,14 @@
 require 'httparty/logger/apache_formatter'
 require 'httparty/logger/curl_formatter'
+require 'httparty/logger/logstash_formatter'
 
 module HTTParty
   module Logger
     def self.formatters
       @formatters ||= {
         :curl => Logger::CurlFormatter,
-        :apache => Logger::ApacheFormatter
+        :apache => Logger::ApacheFormatter,
+        :logstash => Logger::LogstashFormatter,
       }
     end
 

--- a/lib/httparty/logger/logstash_formatter.rb
+++ b/lib/httparty/logger/logstash_formatter.rb
@@ -1,0 +1,59 @@
+module HTTParty
+  module Logger
+    class LogstashFormatter #:nodoc:
+      TAG_NAME = HTTParty.name
+
+      attr_accessor :level, :logger
+
+      def initialize(logger, level)
+        @logger = logger
+        @level  = level.to_sym
+      end
+
+      def format(request, response)
+        @request = request
+        @response = response
+
+        logger.public_send level, logstash_message
+      end
+
+      private
+
+      attr_reader :request, :response
+
+      def logstash_message
+        {
+          '@timestamp' => current_time,
+          '@version' => 1,
+          'content_length' => content_length || '-',
+          'http_method' => http_method,
+          'message' => message,
+          'path' => path,
+          'response_code' => response.code,
+          'severity' => level,
+          'tags' => [TAG_NAME],
+        }.to_json
+      end
+
+      def message
+        "[#{TAG_NAME}] #{response.code} \"#{http_method} #{path}\" #{content_length || '-'} "
+      end
+
+      def current_time
+        Time.now.strftime("%Y-%m-%d %H:%M:%S %z")
+      end
+
+      def http_method
+        @http_method ||= request.http_method.name.split("::").last.upcase
+      end
+
+      def path
+        @path ||= request.path.to_s
+      end
+
+      def content_length
+        @content_length ||= response.respond_to?(:headers) ? response.headers['Content-Length'] : response['Content-Length']
+      end
+    end
+  end
+end

--- a/spec/httparty/logger/logger_spec.rb
+++ b/spec/httparty/logger/logger_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe HTTParty::Logger do
       expect(subject.build(logger_double, nil, :curl)).to be_an_instance_of(HTTParty::Logger::CurlFormatter)
     end
 
+    it "builds :logstash style logger" do
+      logger_double = double
+      expect(subject.build(logger_double, nil, :logstash)).to be_an_instance_of(HTTParty::Logger::LogstashFormatter)
+    end
+
     it "builds :custom style logger" do
       CustomFormatter = Class.new(HTTParty::Logger::CurlFormatter)
       HTTParty::Logger.add_formatter(:custom, CustomFormatter)

--- a/spec/httparty/logger/logstash_formatter_spec.rb
+++ b/spec/httparty/logger/logstash_formatter_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+RSpec.describe HTTParty::Logger::LogstashFormatter do
+  let(:severity) { :info }
+  let(:http_method) { 'GET' }
+  let(:path) { 'http://my.domain.com/my_path' }
+  let(:logger_double) { double('Logger') }
+  let(:request_double) { double('Request', http_method: Net::HTTP::Get, path: "#{path}") }
+  let(:request_time) { Time.new.strftime("%Y-%m-%d %H:%M:%S %z") }
+  let(:log_message) do
+    {
+      '@timestamp' => request_time,
+      '@version' => 1,
+      'content_length' => content_length || '-',
+      'http_method' => http_method,
+      'message' => message,
+      'path' => path,
+      'response_code' => response_code,
+      'severity' => severity,
+      'tags' => ['HTTParty'],
+    }.to_json
+  end
+
+  subject { described_class.new(logger_double, severity) }
+
+  before do
+    expect(logger_double).to receive(:info).with(log_message)
+  end
+
+  describe "#format" do
+    let(:response_code) { 302 }
+    let(:content_length) { '-' }
+    let(:message) { "[HTTParty] #{response_code} \"#{http_method} #{path}\" #{content_length} " }
+
+    it "formats a response to be compatible with Logstash" do
+      response_double = double(
+        code: response_code,
+        :[] => nil
+      )
+
+      subject.format(request_double, response_double)
+    end
+  end
+end


### PR DESCRIPTION
ELK Stack (Elasticsearch, Logstash & Kibana trio) is commonly used today for collecting and presenting logs.

Logstash, to parse logs correctly, needs to have them delivered in a compatible JSON format:

```
{
  "message"    => "hello world",
  "@version"   => "1",
  "@timestamp" => "2018-10-09T23:03:14.111Z",
  "type"       => "stdin",
  "host"       => "hello.local"
}
```

Only `@timestamp` & `@version` are required.

* `@timestamp` is the ISO8601 high-precision timestamp for the event.
* `@version` is the version number of this json schema

Every other field is valid and fine.

To support Logstash format by default I introduced a brand new `LogstashFormatter`. It generates a compatible JSON message with the following fields:

```
{
  "@timestamp" => "2018-10-09 17:54:58 +0200",
  "@version" => 1,
  "content_length" => "512",
  "http_method" => "GET",
  "message" => "[HTTParty] 200 \"GET http://my.domain.com/my_path\" - ",
  "path" => "http://my.domain.com/my_path",
  "response_code" => 200,
  "severity" => "info",
  "tags" => ["HTTParty"]
}
```

The required fields are present + some additional ones which I found useful to have in Kibana for filtering & debugging purpose. Looking forward to your comments.