### PR TITLE
Add more examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -70,3 +70,14 @@
   * Uses `get` requests
   * Uses `stream_body` mode
   * Download file without using the memory
+
+* [Microsoft graph](microsoft_graph.rb)
+  * Basic Auth
+  * Uses `post` requests
+  * Uses multipart
+
+* [Multipart](multipart.rb)
+  * Multipart data upload _(with and without file)_
+
+* [Uploading File](body_stream.rb)
+  * Uses `body_stream` to upload file

--- a/examples/body_stream.rb
+++ b/examples/body_stream.rb
@@ -1,0 +1,14 @@
+# To upload file to a server use :body_stream
+
+HTTParty.put(
+  'http://localhost:3000/train',
+  body_stream: File.open('sample_configs/config_train_server_md.yml', 'r')
+)
+
+
+# Actually, it works with any IO object
+
+HTTParty.put(
+  'http://localhost:3000/train',
+  body_stream: StringIO.new('foo')
+)

--- a/examples/multipart.rb
+++ b/examples/multipart.rb
@@ -1,0 +1,22 @@
+# If you are uploading file in params, multipart will used as content-type automatically
+
+HTTParty.post(
+  'http://localhost:3000/user',
+  body: {
+    name: 'Foo Bar',
+    email: 'example@email.com',
+    avatar: File.open('/full/path/to/avatar.jpg')
+  }
+)
+
+
+# However, you can force it yourself
+
+HTTParty.post(
+  'http://localhost:3000/user',
+  multipart: true,
+  body: {
+    name: 'Foo Bar',
+    email: 'example@email.com'
+  }
+)

--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -41,6 +41,7 @@ module HTTParty
   # [:+local_port:] Local port to bind to before connecting.
   # [:+body_stream:] Allow streaming to a REST server to specify a body_stream.
   # [:+stream_body:] Allow for streaming large files without loading them into memory.
+  # [:+multipart:] Force content-type to be multipart
   #
   # There are also another set of options with names corresponding to various class methods. The methods in question are those that let you set a class-wide default, and the options override the defaults on a request-by-request basis. Those options are:
   # * :+base_uri+: see HTTParty::ClassMethods.base_uri.


### PR DESCRIPTION
Adds examples of `multipart` and `body_stream` options