### PR TITLE
Bump version to 0.16.3

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,13 @@
-## master
 
+## 0.16.3
+* [Add Logstash-compatible formatter](https://github.com/jnunemaker/httparty/pull/612)
+* [Add support for headers specified with symbols](https://github.com/jnunemaker/httparty/pull/622)
+* [Fix response object marshalling](https://github.com/jnunemaker/httparty/pull/618)
+* [Add ability to send multipart, without passing file](https://github.com/jnunemaker/httparty/pull/615)
+* [Fix detection of content_type for multipart payload](https://github.com/jnunemaker/httparty/pull/616)
 * [Process dynamic headers before making actual request](https://github.com/jnunemaker/httparty/pull/606)
 * [Fix multipart uploads with ActionDispatch::Http::UploadedFile TempFile by using original_filename](https://github.com/jnunemaker/httparty/pull/598)
-* Added support for lock and unlock http requests (https://github.com/jnunemaker/httparty/pull/596).
+* [Added support for lock and unlock http requests](https://github.com/jnunemaker/httparty/pull/596)
 
 ## 0.16.2
 

--- a/lib/httparty/version.rb
+++ b/lib/httparty/version.rb
@@ -1,3 +1,3 @@
 module HTTParty
-  VERSION = "0.16.2"
+  VERSION = "0.16.3"
 end


### PR DESCRIPTION
@jnunemaker can you please release a new version?

I want to start working on https://github.com/jnunemaker/httparty/issues/494 and maybe on https://github.com/jnunemaker/httparty/issues/511. Both of these will require minor version update as they may introduce slight backward incompatibility 