### PR TITLE
Cache default certs store to prevent memory leaks

### DIFF
--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -77,6 +77,12 @@ module HTTParty
       new(uri, options).connection
     end
 
+    def self.default_cert_store
+      @default_cert_store ||= OpenSSL::X509::Store.new.tap do |cert_store|
+        cert_store.set_default_paths
+      end
+    end
+
     attr_reader :uri, :options
 
     def initialize(uri, options = {})
@@ -176,8 +182,7 @@ module HTTParty
             http.cert_store = options[:cert_store]
           else
             # Use the default cert store by default, i.e. system ca certs
-            http.cert_store = OpenSSL::X509::Store.new
-            http.cert_store.set_default_paths
+            http.cert_store = self.class.default_cert_store
           end
         else
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,11 @@ RSpec.configure do |config|
 
   config.order = :random
 
+  config.before(:each) do
+    # Reset default_cert_store cache
+    HTTParty::ConnectionAdapter.instance_variable_set(:@default_cert_store, nil)
+  end
+
   Kernel.srand config.seed
 end
 


### PR DESCRIPTION
This was causing me trouble for a while until I figured it out. Interestingly, it's the same issue that's been addressed in [Faraday](https://github.com/lostisland/faraday/pull/793/files#diff-d8775963a7e225c40196fd205b28a626R127) a while ago that I ran into as well and resolved with an upgrade.

The problem is that when doing HTTPS requests the cert store is reinitialized over and over again and we're seeing huge memory leaks in our application over time.