### PR TITLE
HTTParty::Request::Body#multipart? fixes

### DIFF
--- a/lib/httparty/request/body.rb
+++ b/lib/httparty/request/body.rb
@@ -22,7 +22,7 @@ module HTTParty
       end
 
       def multipart?
-        params.respond_to?(:to_hash) && (force_multipart || has_file?(params.to_hash))
+        params.respond_to?(:to_hash) && (force_multipart || file?(params))
       end
 
       private
@@ -46,24 +46,14 @@ module HTTParty
         multipart += "--#{boundary}--\r\n"
       end
 
-      def has_file?(hash)
-        hash.detect do |key, value|
-          if value.respond_to?(:to_hash) || includes_hash?(value)
-            has_file?(value)
-          elsif value.respond_to?(:to_ary)
-            value.any? { |e| file?(e) }
-          else
-            file?(value)
-          end
+      def file?(value)
+        if value.respond_to?(:to_hash)
+          value.to_hash.any? { |_, v| file?(v) }
+        elsif value.respond_to?(:to_ary)
+          value.to_ary.any? { |v| file?(v) }
+        else
+          value.respond_to?(:path) && value.respond_to?(:read)
         end
-      end
-
-      def file?(object)
-        object.respond_to?(:path) && object.respond_to?(:read) # add memoization
-      end
-
-      def includes_hash?(object)
-        object.respond_to?(:to_ary) && object.any? { |e| e.respond_to?(:hash) }
       end
 
       def normalize_query(query)

--- a/lib/httparty/request/body.rb
+++ b/lib/httparty/request/body.rb
@@ -22,7 +22,7 @@ module HTTParty
       end
 
       def multipart?
-        params.respond_to?(:to_hash) && (force_multipart || file?(params))
+        params.respond_to?(:to_hash) && (force_multipart || has_file?(params))
       end
 
       private
@@ -46,14 +46,18 @@ module HTTParty
         multipart += "--#{boundary}--\r\n"
       end
 
-      def file?(value)
+      def has_file?(value)
         if value.respond_to?(:to_hash)
-          value.to_hash.any? { |_, v| file?(v) }
+          value.to_hash.any? { |_, v| has_file?(v) }
         elsif value.respond_to?(:to_ary)
-          value.to_ary.any? { |v| file?(v) }
+          value.to_ary.any? { |v| has_file?(v) }
         else
-          value.respond_to?(:path) && value.respond_to?(:read)
+          file?(value)
         end
+      end
+
+      def file?(object)
+        object.respond_to?(:path) && object.respond_to?(:read)
       end
 
       def normalize_query(query)


### PR DESCRIPTION
This PR intends to fix a few issues with the `multipart?` method:

1. It wasn't working for params that respond to `#to_hash` but not to `#detect` (like `ActionDispatch::Request::Session`). Same for params that respond to `#to_ary` but not to `#detect`
```ruby
class HashLike; def to_hash; { a: 3 }; end; end
HTTParty::Request::Body.new(a: HashLike.new).multipart? # NoMethodError: undefined method `detect' for #<HashLike:0x00007fbf8971ae08>
```

2. Wasn't detecting files inside arrays
(`includes_hash?(value)` was always returning `true` for not empty arrays, because all objects respond to `#hash`, and then it was doing `hash.detect do |key, value| ` with an array which actually yields only one arg)
```ruby
HTTParty::Request::Body.new(a: [Tempfile.new(['some_temp_file','.gif'])]).multipart? # false
```

3. looked like it was intended to be recursive and look for a file inside all hash values or array elements recursively but I think it wasn't doing it (if the method was not supposed to be recursive please let me know because this might impact performance)
