### PR TITLE
Replace c_rehash with openssl rehash - Fixes #604

### DIFF
--- a/spec/fixtures/ssl/generate.sh
+++ b/spec/fixtures/ssl/generate.sh
@@ -12,7 +12,7 @@ mkdir generated
 openssl req -batch -subj '/CN=INSECURE Test Certificate Authority' -newkey rsa:1024 -new -x509 -days 999999 -keyout generated/ca.key -nodes -out generated/ca.crt
 
 # Create symlinks for ssl_ca_path
-c_rehash generated
+openssl generated
 
 # Generate the server private key and self-signed certificate
 openssl req -batch -subj '/CN=localhost' -newkey rsa:1024 -new -x509 -days 999999 -keyout generated/server.key -nodes -out generated/selfsigned.crt


### PR DESCRIPTION
See #604 

Not sure if I should run the file and commit the new certs in spec/fixtures/ssl/generated/

Tests pass both with the old certs and new ones if I generate them again