### PR TITLE
expose .peer_cert on Response

### DIFF
--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -10,7 +10,7 @@ module HTTParty
       new(req, resp, -> { parsed_resp }, body: resp_body)
     end
 
-    attr_reader :request, :response, :body, :headers
+    attr_reader :request, :response, :body, :headers, :peer_cert
 
     def initialize(request, response, parsed_block, options = {})
       @request      = request
@@ -18,6 +18,7 @@ module HTTParty
       @body         = options[:body] || response.body
       @parsed_block = parsed_block
       @headers      = Headers.new(response.to_hash)
+      @peer_cert    = options[:peer_cert]
 
       if request.options[:logger]
         logger = ::HTTParty::Logger.build(

--- a/spec/httparty/ssl_spec.rb
+++ b/spec/httparty/ssl_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 RSpec.describe HTTParty::Request do
   context "SSL certificate verification" do
     before do
-      WebMock.allow_net_connect!
+      WebMock.disable!
     end
 
     after do
-      WebMock.disable_net_connect!
+      WebMock.enable!
     end
 
     it "should fail when no trusted CA list is specified, by default" do
@@ -69,6 +69,10 @@ RSpec.describe HTTParty::Request do
       expect do
         ssl_verify_test(:ssl_ca_path, ".", "bogushost.crt")
       end.to raise_error(OpenSSL::SSL::SSLError)
+    end
+
+    it "should provide the certificate used by the server via peer_cert" do
+      expect(ssl_verify_test(:ssl_ca_file, "ca.crt", "server.crt").peer_cert).to be_a OpenSSL::X509::Certificate
     end
   end
 end

--- a/spec/support/stub_response.rb
+++ b/spec/support/stub_response.rb
@@ -9,6 +9,7 @@ module HTTParty
 
       http_request = HTTParty::Request.new(Net::HTTP::Get, 'http://localhost', format: format)
       allow(http_request).to receive_message_chain(:http, :request).and_return(response)
+      allow(http_request).to receive_message_chain(:http, :peer_cert).and_return(nil)
 
       expect(HTTParty::Request).to receive(:new).and_return(http_request)
     end
@@ -22,6 +23,7 @@ module HTTParty
 
       http_request = HTTParty::Request.new(Net::HTTP::Get, 'http://localhost', options)
       allow(http_request).to receive_message_chain(:http, :request).and_yield(response).and_return(response)
+      allow(http_request).to receive_message_chain(:http, :peer_cert).and_return(nil)
 
       expect(HTTParty::Request).to receive(:new).and_return(http_request)
     end


### PR DESCRIPTION
Closes #633

There are use cases for accessing the X509
certificate used by the server; this commit
exposes this certificate via Response#peer_cert,
which uses the same method name as peer_cert
on the Net::HTTP class:

https://ruby-doc.org/stdlib-2.4.2/libdoc/net/http/rdoc/Net/HTTP.html#method-i-peer_cert