### PR TITLE
Do not stream the body of redirects

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -386,11 +386,12 @@ module HTTParty
     end
 
     def response_redirects?(response = nil)
-      case response || last_response
+      _response = response || last_response
+      case _response
       when Net::HTTPNotModified # 304
         false
       when Net::HTTPRedirection
-        options[:follow_redirects] && last_response.key?('location')
+        options[:follow_redirects] && _response.key?('location')
       end
     end
 

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -143,7 +143,7 @@ module HTTParty
       chunked_body = nil
 
       self.last_response = http.request(@raw_request) do |http_response|
-        if block
+        if block && !(options[:ignore_redirect_body] && response_redirects?(http_response))
           chunks = []
 
           http_response.read_body do |fragment|
@@ -385,8 +385,8 @@ module HTTParty
       !@changed_hosts
     end
 
-    def response_redirects?
-      case last_response
+    def response_redirects?(response = nil)
+      case response || last_response
       when Net::HTTPNotModified # 304
         false
       when Net::HTTPRedirection


### PR DESCRIPTION
Currently, if you use the following code, the body of the redirect is written to the provided block in the request.perform method, and there is no external way to differentiate the redirect body from the destination body.
```ruby
res = []
HTTParty.get('http://example.com') do |data|
  res << data
end
```
For instance, with the above example, imagine the get request to http://example.com returns a page with a status of 302, and a body of "Redirecting to some other page". "Redirecting to some other page" is going to get written to the block that you provided, even though it's probably not what you want and there is currently no way to tell that the data came from the redirect.

Thus, this adds the `ignore_redirect_body` option which allows you to skip the body of the redirects.