### PR TITLE
Add Ruby 2.6 compatibility and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ rvm:
   - 2.3.8
   - 2.4.5
   - 2.5.3
+  - 2.6.0
 bundler_args: --without development
 before_install: gem install bundler

--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -65,6 +65,15 @@ module HTTParty
       alias_method :multiple_choice?, :multiple_choices?
     end
 
+    # Support old status codes method from pre 2.6.0 era.
+    if ::RUBY_VERSION >= "2.6.0" && ::RUBY_PLATFORM != "java"
+      alias_method :gateway_time_out?,                :gateway_timeout?
+      alias_method :request_entity_too_large?,        :payload_too_large?
+      alias_method :request_time_out?,                :request_timeout?
+      alias_method :request_uri_too_long?,            :uri_too_long?
+      alias_method :requested_range_not_satisfiable?, :range_not_satisfiable?
+    end
+
     def nil?
       response.nil? || response.body.nil? || response.body.empty?
     end

--- a/spec/httparty/response_spec.rb
+++ b/spec/httparty/response_spec.rb
@@ -282,6 +282,15 @@ RSpec.describe HTTParty::Response do
         SPECIFIC_CODES[:multiple_choices?] = Net::HTTPMultipleChoices
       end
 
+      # Ruby 2.6, those status codes have been updated.
+      if RUBY_VERSION >= "2.6.0" && ::RUBY_PLATFORM != "java"
+        SPECIFIC_CODES[:gateway_timeout?]       = Net::HTTPGatewayTimeout
+        SPECIFIC_CODES[:payload_too_large?]     = Net::HTTPPayloadTooLarge
+        SPECIFIC_CODES[:request_timeout?]       = Net::HTTPRequestTimeout
+        SPECIFIC_CODES[:uri_too_long?]          = Net::HTTPURITooLong
+        SPECIFIC_CODES[:range_not_satisfiable?] = Net::HTTPRangeNotSatisfiable
+      end
+
       SPECIFIC_CODES.each do |method, klass|
         it "responds to #{method}" do
           net_response = response_mock(klass)


### PR DESCRIPTION
# Add ruby 2.6.0 in Travis CI
# Update HTTP status code methods
On ruby/ruby@660740a75dd9526ad9a2732ea87c8ab5a385ef1f , some status codes have been updated.

Add aliases so old names can still be used with ruby >= 2.6.

Added aliases are:
- `gateway_time_out?` → `gateway_timeout?`
- `request_entity_too_large?` → `payload_too_large?`
- `request_time_out?` → `request_timeout?`
- `request_uri_too_long?` → `uri_too_long?`
- `requested_range_not_satisfiable?` → `range_not_satisfiable?`

It solves issues you will have with ruby 2.6.0 like
~~~
irb(main):001:0> http_response.request_time_out?
NoMethodError: undefined method `request_time_out?' for #<HTTParty::Response:0x0000563c88932270>
Did you mean?  request_timeout?
from …/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/httparty-0.16.2/lib/httparty/response.rb:101:in `method_missing'
~~~