### PR TITLE
Add support for `Net::HTTP#write_timeout` method (Ruby 2.6.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ rvm:
   - 2.3.8
   - 2.4.5
   - 2.5.3
-  - 2.6.0
+  - 2.6.1
 bundler_args: --without development
 before_install: gem install bundler -v '< 2'

--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -173,9 +173,9 @@ module HTTParty
     #     include HTTParty
     #     default_timeout 10
     #   end
-    def default_timeout(t)
-      raise ArgumentError, 'Timeout must be an integer or float' unless t && (t.is_a?(Integer) || t.is_a?(Float))
-      default_options[:timeout] = t
+    def default_timeout(value)
+      validate_timeout_argument(__method__, value)
+      default_options[:timeout] = value
     end
 
     # Allows setting a default open_timeout for all HTTP calls in seconds
@@ -184,9 +184,9 @@ module HTTParty
     #     include HTTParty
     #     open_timeout 10
     #   end
-    def open_timeout(t)
-      raise ArgumentError, 'open_timeout must be an integer or float' unless t && (t.is_a?(Integer) || t.is_a?(Float))
-      default_options[:open_timeout] = t
+    def open_timeout(value)
+      validate_timeout_argument(__method__, value)
+      default_options[:open_timeout] = value
     end
 
     # Allows setting a default read_timeout for all HTTP calls in seconds
@@ -195,9 +195,9 @@ module HTTParty
     #     include HTTParty
     #     read_timeout 10
     #   end
-    def read_timeout(t)
-      raise ArgumentError, 'read_timeout must be an integer or float' unless t && (t.is_a?(Integer) || t.is_a?(Float))
-      default_options[:read_timeout] = t
+    def read_timeout(value)
+      validate_timeout_argument(__method__, value)
+      default_options[:read_timeout] = value
     end
 
     # Allows setting a default write_timeout for all HTTP calls in seconds
@@ -207,9 +207,9 @@ module HTTParty
     #     include HTTParty
     #     write_timeout 10
     #   end
-    def write_timeout(t)
-      raise ArgumentError, 'write_timeout must be an integer or float' unless t && (t.is_a?(Integer) || t.is_a?(Float))
-      default_options[:write_timeout] = t
+    def write_timeout(value)
+      validate_timeout_argument(__method__, value)
+      default_options[:write_timeout] = value
     end
 
 
@@ -575,6 +575,10 @@ module HTTParty
     attr_reader :default_options
 
     private
+
+    def validate_timeout_argument(timeout_type, value)
+      raise ArgumentError, "#{ timeout_type } must be an integer or float" unless value && (value.is_a?(Integer) || value.is_a?(Float))
+    end
 
     def ensure_method_maintained_across_redirects(options)
       unless options.key?(:maintain_method_across_redirects)

--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -200,6 +200,19 @@ module HTTParty
       default_options[:read_timeout] = t
     end
 
+    # Allows setting a default write_timeout for all HTTP calls in seconds
+    # Supported by Ruby > 2.6.0
+    #
+    #   class Foo
+    #     include HTTParty
+    #     write_timeout 10
+    #   end
+    def write_timeout(t)
+      raise ArgumentError, 'write_timeout must be an integer or float' unless t && (t.is_a?(Integer) || t.is_a?(Float))
+      default_options[:write_timeout] = t
+    end
+
+
     # Set an output stream for debugging, defaults to $stderr.
     # The output stream is passed on to Net::HTTP#set_debug_output.
     #

--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -42,6 +42,7 @@ module HTTParty
   # * :+timeout+: timeout in seconds
   # * :+open_timeout+: http connection open_timeout in seconds, overrides timeout if set
   # * :+read_timeout+: http connection read_timeout in seconds, overrides timeout if set
+  # * :+write_timeout+: http connection write_timeout in seconds, overrides timeout if set (Ruby >= 2.6.0 required)
   # * :+debug_output+: see HTTParty::ClassMethods.debug_output.
   # * :+cert_store+: contains certificate data. see method 'attach_ssl_certificates'
   # * :+pem+: contains pem client certificate data. see method 'attach_ssl_certificates'
@@ -116,6 +117,12 @@ module HTTParty
       if options[:timeout] && (options[:timeout].is_a?(Integer) || options[:timeout].is_a?(Float))
         http.open_timeout = options[:timeout]
         http.read_timeout = options[:timeout]
+
+        if RUBY_VERSION >= "2.6.0"
+          http.write_timeout = options[:timeout]
+        else
+          Kernel.warn("Warning: option :write_timeout requires Ruby version 2.6.0 or later")
+        end
       end
 
       if options[:read_timeout] && (options[:read_timeout].is_a?(Integer) || options[:read_timeout].is_a?(Float))
@@ -124,6 +131,14 @@ module HTTParty
 
       if options[:open_timeout] && (options[:open_timeout].is_a?(Integer) || options[:open_timeout].is_a?(Float))
         http.open_timeout = options[:open_timeout]
+      end
+
+      if options[:write_timeout] && (options[:write_timeout].is_a?(Integer) || options[:write_timeout].is_a?(Float))
+        if RUBY_VERSION >= "2.6.0"
+          http.write_timeout = options[:write_timeout]
+        else
+          Kernel.warn("Warning: option :write_timeout requires Ruby version 2.6.0 or later")
+        end
       end
 
       if options[:debug_output]

--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -120,8 +120,6 @@ module HTTParty
 
         if RUBY_VERSION >= "2.6.0"
           http.write_timeout = options[:timeout]
-        else
-          Kernel.warn("Warning: option :write_timeout requires Ruby version 2.6.0 or later")
         end
       end
 

--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -114,7 +114,7 @@ module HTTParty
 
       attach_ssl_certificates(http, options)
 
-      if options[:timeout] && (options[:timeout].is_a?(Integer) || options[:timeout].is_a?(Float))
+      if add_timeout?(options[:timeout])
         http.open_timeout = options[:timeout]
         http.read_timeout = options[:timeout]
 
@@ -125,15 +125,15 @@ module HTTParty
         end
       end
 
-      if options[:read_timeout] && (options[:read_timeout].is_a?(Integer) || options[:read_timeout].is_a?(Float))
+      if add_timeout?(options[:read_timeout])
         http.read_timeout = options[:read_timeout]
       end
 
-      if options[:open_timeout] && (options[:open_timeout].is_a?(Integer) || options[:open_timeout].is_a?(Float))
+      if add_timeout?(options[:open_timeout])
         http.open_timeout = options[:open_timeout]
       end
 
-      if options[:write_timeout] && (options[:write_timeout].is_a?(Integer) || options[:write_timeout].is_a?(Float))
+      if add_timeout?(options[:write_timeout])
         if RUBY_VERSION >= "2.6.0"
           http.write_timeout = options[:write_timeout]
         else
@@ -172,6 +172,10 @@ module HTTParty
     end
 
     private
+
+    def add_timeout?(timeout)
+      timeout && (timeout.is_a?(Integer) || timeout.is_a?(Float))
+    end
 
     def clean_host(host)
       strip_ipv6_brackets(host)

--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -118,7 +118,7 @@ module HTTParty
         http.open_timeout = options[:timeout]
         http.read_timeout = options[:timeout]
 
-        if RUBY_VERSION >= "2.6.0"
+        from_ruby_version('2.6.0', option: :write_timeout, warn: false) do
           http.write_timeout = options[:timeout]
         end
       end
@@ -132,10 +132,8 @@ module HTTParty
       end
 
       if add_timeout?(options[:write_timeout])
-        if RUBY_VERSION >= "2.6.0"
+        from_ruby_version('2.6.0', option: :write_timeout) do
           http.write_timeout = options[:write_timeout]
-        else
-          Kernel.warn("Warning: option :write_timeout requires Ruby version 2.6.0 or later")
         end
       end
 
@@ -151,18 +149,14 @@ module HTTParty
       #
       # @see https://bugs.ruby-lang.org/issues/6617
       if options[:local_host]
-        if RUBY_VERSION >= "2.0.0"
+        from_ruby_version('2.0.0', option: :local_host) do
           http.local_host = options[:local_host]
-        else
-          Kernel.warn("Warning: option :local_host requires Ruby version 2.0 or later")
         end
       end
 
       if options[:local_port]
-        if RUBY_VERSION >= "2.0.0"
+        from_ruby_version('2.0.0', option: :local_port) do
           http.local_port = options[:local_port]
-        else
-          Kernel.warn("Warning: option :local_port requires Ruby version 2.0 or later")
         end
       end
 
@@ -170,6 +164,14 @@ module HTTParty
     end
 
     private
+
+    def from_ruby_version(ruby_version, option: nil, warn: true)
+      if RUBY_VERSION >= ruby_version
+        yield
+      elsif warn
+        Kernel.warn("Warning: option #{ option } requires Ruby version #{ ruby_version } or later")
+      end
+    end
 
     def add_timeout?(timeout)
       timeout && (timeout.is_a?(Integer) || timeout.is_a?(Float))

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -329,6 +329,10 @@ RSpec.describe HTTParty do
       @klass.default_timeout 0.5
       expect(@klass.default_options[:timeout]).to eq(0.5)
     end
+
+    it "should raise an exception if unsupported type provided" do
+      expect { @klass.default_timeout "0.5" }.to raise_error ArgumentError
+    end
   end
 
   describe "debug_output" do


### PR DESCRIPTION
[The method](https://ruby-doc.org/stdlib-2.6/libdoc/net/http/rdoc/Net/HTTP.html#method-i-write_timeout-3D) was introduced in Ruby 2.6.0.

The gem already supports `open_timeout` & `read_timeout` options, so it would be nice to provide support for `write_timeout` as well.

From the official documentation:

> Number of seconds to wait for one block to be written (via one write(2) call). Any number may be used, including Floats for fractional seconds. If the HTTP object cannot write data in this many seconds, it raises a Net::WriteTimeout exception. The default value is 60 seconds. Net::WriteTimeout is not raised on Windows.