### PR TITLE
Avoid modifying frozen strings

### DIFF
--- a/lib/httparty/text_encoder.rb
+++ b/lib/httparty/text_encoder.rb
@@ -33,16 +33,16 @@ module HTTParty
     def encode_utf_16
       if text.bytesize >= 2
         if text.getbyte(0) == 0xFF && text.getbyte(1) == 0xFE
-          return text.force_encoding("UTF-16LE")
+          return text.dup.force_encoding("UTF-16LE")
         elsif text.getbyte(0) == 0xFE && text.getbyte(1) == 0xFF
-          return text.force_encoding("UTF-16BE")
+          return text.dup.force_encoding("UTF-16BE")
         end
       end
 
       if assume_utf16_is_big_endian # option
-        text.force_encoding("UTF-16BE")
+        text.dup.force_encoding("UTF-16BE")
       else
-        text.force_encoding("UTF-16LE")
+        text.dup.force_encoding("UTF-16LE")
       end
     end
 
@@ -50,7 +50,7 @@ module HTTParty
       # NOTE: This will raise an argument error if the
       # charset does not exist
       encoding = Encoding.find(charset)
-      text.force_encoding(encoding.to_s)
+      text.dup.force_encoding(encoding.to_s)
     rescue ArgumentError
       text
     end


### PR DESCRIPTION
Calling the `force_encoding` method on frozen strings can be a problem.
Especially for people using the `# frozen_string_literal: true` annotation.

To protect it, I added a call to `dup` before all calls to `force_encoding`.
If we decide the bump the ruby version to something newer we could use the `+`.

Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>