### PR TITLE
Add blank? method to check for when response & body is nil or empty.

### DIFF
--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -78,6 +78,10 @@ module HTTParty
       response.nil? || response.body.nil? || response.body.empty?
     end
 
+    def blank?
+      nil?
+    end
+
     def to_s
       if !response.nil? && !response.body.nil? && response.body.respond_to?(:to_s)
         response.body.to_s

--- a/spec/httparty/response_spec.rb
+++ b/spec/httparty/response_spec.rb
@@ -194,6 +194,28 @@ RSpec.describe HTTParty::Response do
     it { expect(subject.kind_of?(Object)).to be_truthy }
   end
 
+  describe "blank?" do
+    it "is blank due to empty body" do
+      allow(@response_object).to receive_messages(body: "")
+      @parsed_response = lambda { "" }
+      @response = HTTParty::Response.new(@request_object, @response_object, @parsed_response)
+
+      expect(@response.blank?).to be_truthy
+    end
+
+    it "is not blank" do
+      expect(@response.blank?).to be_falsey
+    end
+
+    it "is nil and thus is also considered blank" do
+      allow(@response_object).to receive_messages(body: nil)
+      @parsed_response = lambda { nil }
+      @response = HTTParty::Response.new(@request_object, @response_object, @parsed_response)
+
+      expect(@response.blank?).to be_truthy
+    end
+  end
+
   describe "semantic methods for response codes" do
     def response_mock(klass)
       response = klass.new('', '', '')


### PR DESCRIPTION
This PR is to add a `blank?` method to the `Response` class. Currently, `Response` overrides `nil?` as so

https://github.com/jnunemaker/httparty/blob/e1421556f6e0a9d86c1026a14a3969c7a382a92b/lib/httparty/response.rb#L77

This is fine, however, I feel that if you're going to override `nil?`, you should also override `blank?` to behave similarly. Currently, `.blank?` will return false when `nil?` is true due to `response.body.empty?` returning true, which is confusing and can lead to nasty, hard to track bugs.

For example, if you call `HTTParty.get("https://httpbin.org/status/204")`, this will return a response with an empty body and `response.blank?` returns false. I believe it should return true. 