### PR TITLE
Remove test_files from gemspec

### DIFF
--- a/httparty.gemspec
+++ b/httparty.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
   s.files         = all_files - test_files
-  s.test_files    = test_files
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
`#test_files`seem to be redundant https://github.com/rubygems/rubygems/issues/735

By removing test files from the gem, it becomes two times lighter _(From 90.5KiB to 42.5KiB)_