### PR TITLE
Handle invalid JSON in Response#inspect

### DIFF
--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -50,7 +50,15 @@ module HTTParty
 
     def inspect
       inspect_id = ::Kernel::format "%x", (object_id * 2)
-      %(#<#{self.class}:0x#{inspect_id} parsed_response=#{parsed_response.inspect}, @response=#{response.inspect}, @headers=#{headers.inspect}>)
+
+      parsed_response_or_body =
+        begin
+          "parsed_response=#{parsed_response.inspect}"
+        rescue JSON::ParserError
+          "parsed_response=<invalid>, body=#{body.inspect}"
+        end
+
+      %(#<#{self.class}:0x#{inspect_id} #{parsed_response_or_body}, @response=#{response.inspect}, @headers=#{headers.inspect}>)
     end
 
     CODES_TO_OBJ = ::Net::HTTPResponse::CODE_CLASS_TO_OBJ.merge ::Net::HTTPResponse::CODE_TO_OBJ

--- a/spec/httparty/response_spec.rb
+++ b/spec/httparty/response_spec.rb
@@ -358,6 +358,16 @@ RSpec.describe HTTParty::Response do
       expect(inspect).to include("last-modified")
       expect(inspect).to include("content-length")
     end
+
+    it "works when the parsed_response is not valid JSON (e.g. a non-JSON error response to a JSON request)" do
+      allow(@response_object).to receive_messages(body: "boom")
+      parsed_response = lambda { raise(JSON::ParserError) }
+      response = HTTParty::Response.new(@request_object, @response_object, parsed_response)
+      inspect = response.inspect
+
+      expect(inspect).to include("parsed_response=<invalid>")
+      expect(inspect).to include("body=\"boom\"")
+    end
   end
 
   describe 'marshalling' do


### PR DESCRIPTION
See #421.

There are a few things I'm unsure about here, but see it at a starting point for a discussion:

* Can this happen for other formats than JSON as well, and do we want to handle those? (Personally I'd be happy with this one for now, and we can support more as the need arises.)

* Since this is not a very integrated test, I'm not super confident about whether this will work as intended IRL. Is there a better place or way I could test it? Or does this seem a reasonable way to test it?