### PR TITLE
Add max_retries support

### DIFF
--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -137,6 +137,12 @@ module HTTParty
         end
       end
 
+      if add_max_retries?(options[:max_retries])
+        from_ruby_version('2.5.0', option: :max_retries) do
+          http.max_retries = options[:max_retries]
+        end
+      end
+
       if options[:debug_output]
         http.set_debug_output(options[:debug_output])
       end
@@ -175,6 +181,10 @@ module HTTParty
 
     def add_timeout?(timeout)
       timeout && (timeout.is_a?(Integer) || timeout.is_a?(Float))
+    end
+
+    def add_max_retries?(max_retries)
+      max_retries && max_retries.is_a?(Integer) && max_retries >= 0
     end
 
     def clean_host(host)

--- a/spec/httparty/connection_adapter_spec.rb
+++ b/spec/httparty/connection_adapter_spec.rb
@@ -399,6 +399,58 @@ RSpec.describe HTTParty::ConnectionAdapter do
         end
       end
 
+      context "when max_retries is not set" do
+        it "doesn't set the max_retries" do
+          http = double(
+            "http",
+            :null_object => true,
+            :use_ssl= => false,
+            :use_ssl? => false
+          )
+          expect(http).not_to receive(:max_retries=)
+          allow(Net::HTTP).to receive_messages(new: http)
+
+          adapter.connection
+        end
+      end
+
+      context "when setting max_retries" do
+        if RUBY_VERSION >= '2.5.0'
+          context "to 5 times" do
+            let(:options) { {max_retries: 5} }
+            describe '#max_retries' do
+              subject { super().max_retries }
+              it { is_expected.to eq(5) }
+            end
+          end
+
+          context "to 0 times" do
+            let(:options) { {max_retries: 0} }
+            describe '#max_retries' do
+              subject { super().max_retries }
+              it { is_expected.to eq(0) }
+            end
+          end
+        end
+
+        context "and max_retries is a string" do
+          let(:options) { {max_retries: "five times"} }
+
+          it "doesn't set the max_retries" do
+            http = double(
+              "http",
+              :null_object => true,
+              :use_ssl= => false,
+              :use_ssl? => false
+            )
+            expect(http).not_to receive(:max_retries=)
+            allow(Net::HTTP).to receive_messages(new: http)
+
+            adapter.connection
+          end
+        end
+      end
+
       context "when debug_output" do
         let(:http) { Net::HTTP.new(uri) }
         before do


### PR DESCRIPTION
`Net::HTTP` had this weird behaviour of retry once on timeout for `GET` & `PUT` requests. On Ruby 2.5.0 `Net::HTTP` introduced retry configuration option https://github.com/ruby/ruby/pull/1654

Found out that `HTTParty` doesn't support it yet. I added `max_retries` option pass to `Net::HTTP` from `ConnectionAdapter`