### PR TITLE
Pass options to dynamic block headers

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -17,6 +17,7 @@ require 'httparty/logger/logger'
 require 'httparty/request/body'
 require 'httparty/response_fragment'
 require 'httparty/text_encoder'
+require 'httparty/headers_processor'
 
 # @see HTTParty::ClassMethods
 module HTTParty
@@ -588,26 +589,9 @@ module HTTParty
 
     def perform_request(http_method, path, options, &block) #:nodoc:
       options = ModuleInheritableAttributes.hash_deep_dup(default_options).merge(options)
-      process_headers(options)
+      HeadersProcessor.new(headers, options).call
       process_cookies(options)
       Request.new(http_method, path, options).perform(&block)
-    end
-
-    def process_headers(options)
-      if options[:headers]
-        if headers.any?
-          options[:headers] = headers.merge(options[:headers])
-        end
-
-        options[:headers] = Utils.stringify_keys(process_dynamic_headers(options[:headers]))
-      end
-    end
-
-    def process_dynamic_headers(headers)
-      headers.each_with_object({}) do |header, processed_headers|
-        key, value = header
-        processed_headers[key] = value.respond_to?(:call) ? value.call : value
-      end
     end
 
     def process_cookies(options) #:nodoc:

--- a/lib/httparty/headers_processor.rb
+++ b/lib/httparty/headers_processor.rb
@@ -1,0 +1,30 @@
+module HTTParty
+  class HeadersProcessor
+    attr_reader :headers, :options
+
+    def initialize(headers, options)
+      @headers = headers
+      @options = options
+    end
+
+    def call
+      return unless options[:headers]
+
+      options[:headers] = headers.merge(options[:headers]) if headers.any?
+      options[:headers] = Utils.stringify_keys(process_dynamic_headers)
+    end
+
+    private
+
+    def process_dynamic_headers
+      options[:headers].each_with_object({}) do |header, processed_headers|
+        key, value = header
+        processed_headers[key] = if value.respond_to?(:call)
+                                   value.arity == 0 ? value.call : value.call(options)
+                                 else
+                                   value
+                                 end
+      end
+    end
+  end
+end

--- a/spec/httparty/headers_processor_spec.rb
+++ b/spec/httparty/headers_processor_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+RSpec.describe HTTParty::HeadersProcessor do
+  subject(:headers) { options[:headers] }
+  let(:options) { { headers: {} } }
+  let(:global_headers) { {} }
+
+  before { described_class.new(global_headers, options).call }
+
+  context 'when headers are not set at all' do
+    it 'returns empty hash' do
+      expect(headers).to eq({})
+    end
+  end
+
+  context 'when only global headers are set' do
+    let(:global_headers) { { accept: 'text/html' } }
+
+    it 'returns stringified global headers' do
+      expect(headers).to eq('accept' => 'text/html')
+    end
+  end
+
+  context 'when only request specific headers are set' do
+    let(:options) { { headers: {accept: 'text/html' } } }
+
+    it 'returns stringified request specific headers' do
+      expect(headers).to eq('accept' => 'text/html')
+    end
+  end
+
+  context 'when global and request specific headers are set' do
+    let(:global_headers) { { 'x-version' => '123' } }
+
+    let(:options) { { headers: { accept: 'text/html' } } }
+
+    it 'returns merged global and request specific headers' do
+      expect(headers).to eq('accept' => 'text/html', 'x-version' => '123')
+    end
+  end
+
+  context 'when headers are dynamic' do
+    let(:global_headers) { {'x-version' => -> { 'abc'.reverse } } }
+
+    let(:options) do
+      { body: '123',
+        headers: { sum: lambda { |options| options[:body].chars.map(&:to_i).inject(:+) } } }
+    end
+
+    it 'returns processed global and request specific headers' do
+      expect(headers).to eq('sum' => 6, 'x-version' => 'cba')
+    end
+  end
+end

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -154,6 +154,16 @@ RSpec.describe HTTParty do
       expect(@klass.headers).to eq(init_headers)
     end
 
+    it "should pass options as argument to header block value" do
+      init_headers = { 'foo' => lambda { |options| options[:body] } }
+      @klass.headers init_headers
+
+      stub_request(:get, "http://example.com/").with(body: 'bar',  headers: { 'foo' => 'bar', 'baz' => 'rab' })
+
+      @klass.get('http://example.com/', body: 'bar',headers: { 'baz' => -> (options){ options[:body].reverse } })
+      expect(@klass.headers).to eq(init_headers)
+    end
+
     it "uses the class headers when sending a request" do
       expect_headers('foo' => 'bar')
       @klass.headers(foo: 'bar')


### PR DESCRIPTION
I encountered the following problem: API required checksum based on the request body.

This simple change allows using request options in block header like in this example:

```ruby
headers 'X-SIGNATURE' => lambda { |options|
          Digest::SHA256.hexdigest(options[:body] + configuration.api_secret)
        }
```