### PR TITLE
Point to correct PR URL for `max_retries`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 * [Pass options to dynamic block headers](https://github.com/jnunemaker/httparty/pull/661)
 * [Normalize urls with URI adapter to allow International Domain Names support](https://github.com/jnunemaker/httparty/pull/668)
-* [Add max_retries support](https://github.com/jnunemaker/httparty/pull/648)
+* [Add max_retries support](https://github.com/jnunemaker/httparty/pull/660)
 * [Minize gem size by removing test files](https://github.com/jnunemaker/httparty/pull/658)
 
 ## 0.17.0


### PR DESCRIPTION
Just a small update to point to https://github.com/jnunemaker/httparty/pull/660 for `max_retries` information - looks like an incorrect one got copy/pasted in the changelog.