### PR TITLE
Consider parsed_response when checking nil?

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [`Response.nil?` now considers the parsed response]()
+
 ## 0.17.1
 
 * [Pass options to dynamic block headers](https://github.com/jnunemaker/httparty/pull/661)

--- a/lib/httparty/response.rb
+++ b/lib/httparty/response.rb
@@ -79,7 +79,8 @@ module HTTParty
     end
 
     def nil?
-      response.nil? || response.body.nil? || response.body.empty?
+      response.nil? || response.body.nil? || response.body.empty? ||
+      parsed_response.nil? || parsed_response.empty?
     end
 
     def to_s

--- a/spec/httparty/response_spec.rb
+++ b/spec/httparty/response_spec.rb
@@ -39,11 +39,11 @@ RSpec.describe HTTParty::Response do
     it "should set code" do
       expect(@response.code).to eq(@response_object.code)
     end
-        
+
     it "should set code as an Integer" do
       expect(@response.code).to be_a(Integer)
     end
-    
+
     it "should set http_version" do
       unparseable_body = lambda { raise "Unparseable" }
       unparseable_response = HTTParty::Response.new(@request_object, @response_object, unparseable_body)
@@ -357,6 +357,63 @@ RSpec.describe HTTParty::Response do
       expect(inspect).to include("@headers={")
       expect(inspect).to include("last-modified")
       expect(inspect).to include("content-length")
+    end
+  end
+
+  describe "#nil?" do
+    it "returns false if the response is exists" do
+      response = HTTParty::Response.new(@request_object, @response_object, @parsed_response)
+
+      expect(response).to_not be_nil
+    end
+
+    it "returns true if the response is nil" do
+      net_response = Net::HTTPRedirection.new('', '', '')
+      allow(net_response).to receive(:body)
+
+      response = HTTParty::Response.new(@request_object, net_response, '')
+
+      expect(response).to be_nil
+    end
+
+    it "returns true if the response body is nil" do
+      response_object = Net::HTTPOK.new('1.1', 200, 'OK')
+      allow(response_object).to receive_messages(body: nil)
+      parsed_response = lambda { nil }
+
+      response = HTTParty::Response.new(@request_object, response_object, parsed_response)
+
+      expect(response).to be_nil
+    end
+
+    it "returns true if the response body is empty" do
+      response_object = Net::HTTPOK.new('1.1', 200, 'OK')
+      allow(response_object).to receive_messages(body: '')
+      parsed_response = lambda { '' }
+
+      response = HTTParty::Response.new(@request_object, response_object, parsed_response)
+
+      expect(response).to be_nil
+    end
+
+    it "returns true if the parsed response is nil" do
+      response_object = Net::HTTPOK.new('1.1', 200, 'OK')
+      allow(response_object).to receive_messages(body: 'null')
+      parsed_response = lambda { nil }
+
+      response = HTTParty::Response.new(@request_object, response_object, parsed_response)
+
+      expect(response).to be_nil
+    end
+
+    it "returns true if the parsed response is empty" do
+      response_object = Net::HTTPOK.new('1.1', 200, 'OK')
+      allow(response_object).to receive_messages(body: 'foo')
+      parsed_response = lambda { '' }
+
+      response = HTTParty::Response.new(@request_object, response_object, parsed_response)
+
+      expect(response).to be_nil
     end
   end
 


### PR DESCRIPTION
This PR expands `Response.nil?` to _also_ consider the `parsed_response` before determining the result. I noticed there were no tests for the `nil?` behaviour, so I added them to help prevent regressions.

I tend to agree with https://github.com/jnunemaker/httparty/issues/568, but this PR fixes the current code to behave more predictably with JSON API's.

---

This all came about because our project updated from HTTParty 0.14 to 0.17.1 and broke our application in production. 

Our code called a JSON API which returned "null" when it no results were found. We used `response.nil?` to determine when to do a fallback, otherwise we carried on as if we had a JSON object.

In doing a deep dive it turned out that introducing the `nil?` method in https://github.com/jnunemaker/httparty/pull/513/commits/e8d1ecf6268730dc1e95ec7d03e3ddb4359dc911 (v0.15.0) changed this behaviour. Previously I believe `nil?` would be delegated to `method_missing?` which would try `parsed_response` first, then fallback to `response`. 

The `Parser` already handles the case of `'null'` so `response.parsed_response` will be set to `nil`:

https://github.com/jnunemaker/httparty/blob/f2b431454fe50c64ddd42fb411338a7aa92df94b/lib/httparty/parser.rb#L102-L104

However, because the new implementation of `response.nil?` doesn't check `parsed_response`, the result of calling `nil?` is false, because the _original_ body string is `null` which is neither nil nor blank 😅 