### PR TITLE
Support gzip/deflate transfer encoding when explicit headers are set.

### DIFF
--- a/features/handles_compressed_responses.feature
+++ b/features/handles_compressed_responses.feature
@@ -2,7 +2,7 @@ Feature: Handles Compressed Responses
 
   In order to save bandwidth
   As a developer
-  I want to uncompress compressed responses
+  I want to leverage Net::Http's built in transparent support for gzip and deflate content encoding
 
   Scenario: Supports deflate encoding
     Given a remote deflate service
@@ -10,6 +10,7 @@ Feature: Handles Compressed Responses
     And that service is accessed at the path '/deflate_service.html'
     When I call HTTParty#get with '/deflate_service.html'
     Then the return value should match '<h1>Some HTML</h1>'
+    And it should return a response without a content-encoding
 
   Scenario: Supports gzip encoding
     Given a remote gzip service
@@ -17,11 +18,23 @@ Feature: Handles Compressed Responses
     And that service is accessed at the path '/gzip_service.html'
     When I call HTTParty#get with '/gzip_service.html'
     Then the return value should match '<h1>Some HTML</h1>'
+    And it should return a response without a content-encoding
 
-  Scenario: Supports HEAD request with gzip encoding
+  Scenario: Supports gzip encoding with explicit header set
     Given a remote gzip service
-    And that service is accessed at the path '/gzip_head.gz.js'
-    When I call HTTParty#head with '/gzip_head.gz.js'
-    Then it should return a response with a 200 response code
-    Then it should return a response with a gzip content-encoding
-    Then it should return a response with a blank body
+    And the response from the service has a body of '<h1>Some HTML</h1>'
+    And that service is accessed at the path '/gzip_service.html'
+    When I set my HTTParty header 'User-Agent' to value 'Party'
+    And I call HTTParty#get with '/gzip_service.html'
+    Then the return value should match '<h1>Some HTML</h1>'
+    And it should return a response without a content-encoding
+
+  Scenario: Supports deflate encoding with explicit header set
+    Given a remote deflate service
+    And the response from the service has a body of '<h1>Some HTML</h1>'
+    And that service is accessed at the path '/deflate_service.html'
+    When I set my HTTParty header 'User-Agent' to value 'Party'
+    And I call HTTParty#get with '/deflate_service.html'
+    Then the return value should match '<h1>Some HTML</h1>'
+    And it should return a response without a content-encoding
+

--- a/features/steps/httparty_response_steps.rb
+++ b/features/steps/httparty_response_steps.rb
@@ -38,12 +38,8 @@ Then /it should return a response with a (\d+) response code/ do |code|
   expect(@response_from_httparty.code).to eq(code.to_i)
 end
 
-Then /it should return a response with a (.*) content\-encoding$/ do |content_type|
-  expect(@response_from_httparty.headers['content-encoding']).to eq('gzip')
-end
-
-Then /it should return a response with a blank body$/ do
-  expect(@response_from_httparty.body).to be_nil
+Then /it should return a response without a content\-encoding$/ do
+  expect(@response_from_httparty.headers['content-encoding']).to be_nil
 end
 
 Then /it should raise (?:an|a) ([\w:]+) exception/ do |exception|

--- a/features/steps/httparty_steps.rb
+++ b/features/steps/httparty_steps.rb
@@ -10,6 +10,11 @@ When /^I set my HTTParty read_timeout option to (\d+)$/ do |timeout|
   @request_options[:read_timeout] = timeout.to_i
 end
 
+When /^I set my HTTParty header '(.*)' to value '(.*)'$/ do |name, value|
+  @request_options[:headers] ||= {}
+  @request_options[:headers][name] = value
+end
+
 When /I call HTTParty#get with '(.*)'$/ do |url|
   begin
     @response_from_httparty = HTTParty.get("http://#{@host_and_port}#{url}", @request_options)

--- a/features/steps/mongrel_helper.rb
+++ b/features/steps/mongrel_helper.rb
@@ -25,18 +25,28 @@ end
 
 class DeflateHandler < BasicMongrelHandler
   def process(request, response)
-    response.start do |head, body|
-      head['Content-Encoding'] = 'deflate'
-      body.write Zlib::Deflate.deflate(response_body)
+    accept_encoding = request.params["HTTP_ACCEPT_ENCODING"]
+    if accept_encoding.nil? || !accept_encoding.include?('deflate')
+      reply_with(response, 406, 'No deflate accept encoding found in request')
+    else
+      response.start do |head, body|
+        head['Content-Encoding'] = 'deflate'
+        body.write Zlib::Deflate.deflate(response_body)
+      end
     end
   end
 end
 
 class GzipHandler < BasicMongrelHandler
   def process(request, response)
-    response.start do |head, body|
-      head['Content-Encoding'] = 'gzip'
-      body.write gzip(response_body)
+    accept_encoding = request.params["HTTP_ACCEPT_ENCODING"]
+    if accept_encoding.nil? || !accept_encoding.include?('gzip')
+      reply_with(response, 406, 'No gzip accept encoding found in request')
+    else
+      response.start do |head, body|
+        head['Content-Encoding'] = 'gzip'
+        body.write gzip(response_body)
+      end
     end
   end
 

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -204,21 +204,14 @@ module HTTParty
     end
 
     def setup_raw_request
-      @raw_request = http_method.new(request_uri(uri))
-      @raw_request.body_stream = options[:body_stream] if options[:body_stream]
-
       if options[:headers].respond_to?(:to_hash)
         headers_hash = options[:headers].to_hash
-
-        @raw_request.initialize_http_header(headers_hash)
-        # If the caller specified a header of 'Accept-Encoding', assume they want to
-        # deal with encoding of content. Disable the internal logic in Net:HTTP
-        # that handles encoding, if the platform supports it.
-        if @raw_request.respond_to?(:decode_content) && (headers_hash.key?('Accept-Encoding') || headers_hash.key?('accept-encoding'))
-          # Using the '[]=' sets decode_content to false
-          @raw_request['accept-encoding'] = @raw_request['accept-encoding']
-        end
+      else
+        headers_hash = nil
       end
+
+      @raw_request = http_method.new(request_uri(uri), headers_hash)
+      @raw_request.body_stream = options[:body_stream] if options[:body_stream]
 
       if options[:body]
         body = Body.new(


### PR DESCRIPTION
httparty relies on Net::HTTP's built in transparent support for gzip and deflate
transfer encoding, however that did not work if you specified your own explicit headers
because calling Net::HTTPHeader#initialize_http_header overwrites the work done in
Net::HTTPGenericRequest#initialize to set the default User-Agent, Accept,
and Accept-Encoding.  This also removes the need to duplicate the logic in
Net::HTTP around not decoding the response if the caller has explicitly set
the Accept-Encoding for their own purposes.

This does introduce a slight incompatible change in behavior where
previously specifying any custom headers would omit the default headers,
while with the new behavior you can override the values however
can't omit them entirely.

While I'm here, also remove the test for HEAD requests added in
4797c7696dfcb05c9a5b2ad4748bba90c3883263 because it was not properly
testing what it claimed to and the code it was trying to test was
removed in 6f6bf6b726484eaf50e190769bbe14c9841a2c64 anyway.