### PR TITLE
Update some attributes rdoc format

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -41,11 +41,11 @@ module HTTParty
   # [:+limit+:] Maximum number of redirects to follow. Takes precedences over :+no_follow+.
   # [:+query+:] Query string, or an object that responds to #to_hash representing it. Normalized according to the same rules as :+body+. If you specify this on a POST, you must use an object which responds to #to_hash. See also HTTParty::ClassMethods.default_params.
   # [:+timeout+:] Timeout for opening connection and reading data.
-  # [:+local_host:] Local address to bind to before connecting.
-  # [:+local_port:] Local port to bind to before connecting.
-  # [:+body_stream:] Allow streaming to a REST server to specify a body_stream.
-  # [:+stream_body:] Allow for streaming large files without loading them into memory.
-  # [:+multipart:] Force content-type to be multipart
+  # [:+local_host+:] Local address to bind to before connecting.
+  # [:+local_port+:] Local port to bind to before connecting.
+  # [:+body_stream+:] Allow streaming to a REST server to specify a body_stream.
+  # [:+stream_body+:] Allow for streaming large files without loading them into memory.
+  # [:+multipart+:] Force content-type to be multipart
   #
   # There are also another set of options with names corresponding to various class methods. The methods in question are those that let you set a class-wide default, and the options override the defaults on a request-by-request basis. Those options are:
   # * :+base_uri+: see HTTParty::ClassMethods.base_uri.


### PR DESCRIPTION
There is some attributes that don't follow the rdoc attributes format. 

Example:
https://rdoc.info/github/jnunemaker/httparty/HTTParty/ClassMethods

![image](https://user-images.githubusercontent.com/750998/73000990-03a19800-3e02-11ea-98bd-592155538c3b.png)
