### PR TITLE
Support edge case cookie format with a blank attribute

### DIFF
--- a/lib/httparty/cookie_hash.rb
+++ b/lib/httparty/cookie_hash.rb
@@ -8,7 +8,7 @@ class HTTParty::CookieHash < Hash #:nodoc:
     when String
       value.split('; ').each do |cookie|
         array = cookie.split('=', 2)
-        self[array[0].to_sym] = array[1]
+        self[array[0].to_sym] = array[1] if array[0]
       end
     else
       raise "add_cookies only takes a Hash or a String"

--- a/spec/httparty/cookie_hash_spec.rb
+++ b/spec/httparty/cookie_hash_spec.rb
@@ -42,6 +42,11 @@ RSpec.describe HTTParty::CookieHash do
         expect(@cookie_hash[:first]).to eq('one=1')
         expect(@cookie_hash[:second]).to eq('two=2==')
       end
+
+      it "should handle an empty cookie parameter" do
+        @cookie_hash.add_cookies("first=one; domain=mydomain.com; path=/; ; SameSite; Secure")
+        expect(@cookie_hash.keys).to include(:first, :domain, :path, :SameSite, :Secure)
+      end
     end
 
     describe 'with other class' do


### PR DESCRIPTION
Akamai, whether due to a bug or intentional change, started to send HTTP responses with Set-Cookie headers that appear to violate the Cookie RFC by including a blank parameter. Traditional browsers appear to handle the change without issue, but HTTParty throws an exception when copying this cookie from the response to a subsequent request.

Sample invalid header:
```
Set-Cookie: somekey=someval; domain=mydomain.com; path=/; ; Secure
```

This change silently drops the invalid parameter and treats the remainder of the header as valid.