### PR TITLE
cookie_hash.rb cleanup

### DIFF
--- a/lib/httparty/cookie_hash.rb
+++ b/lib/httparty/cookie_hash.rb
@@ -1,14 +1,14 @@
 class HTTParty::CookieHash < Hash #:nodoc:
   CLIENT_COOKIES = %w(path expires domain path secure httponly samesite)
 
-  def add_cookies(value)
-    case value
+  def add_cookies(data)
+    case data
     when Hash
-      merge!(value)
+      merge!(data)
     when String
-      value.split('; ').each do |cookie|
-        array = cookie.split('=', 2)
-        self[array[0].to_sym] = array[1] if array[0]
+      data.split('; ').each do |cookie|
+        key, value = cookie.split('=', 2)
+        self[key.to_sym] = value if key
       end
     else
       raise "add_cookies only takes a Hash or a String"


### PR DESCRIPTION
Just a small thing I saw when looking at the gem diff.

Renamed "value" to "data" so we don't have two things named "value" in the same context.

Possibly "k" and "v" would be better since it's more consistent with `to_cookie_string`.