### PR TITLE
Follow absolute path when redirect location contains ".." (#582)

### DIFF
--- a/features/steps/remote_service_steps.rb
+++ b/features/steps/remote_service_steps.rb
@@ -49,6 +49,10 @@ Given /the url '(.*)' redirects to '(.*)'/ do |redirection_url, target_url|
   @server.register redirection_url, new_mongrel_redirector(target_url)
 end
 
+Given /the url '(.*)' redirects to the relative path '(.*)'/ do |redirection_url, target_url|
+  @server.register redirection_url, new_mongrel_redirector(target_url, true)
+end
+
 Given /that service is protected by Basic Authentication/ do
   @handler.extend BasicAuthentication
 end

--- a/features/supports_redirection.feature
+++ b/features/supports_redirection.feature
@@ -14,6 +14,11 @@ Feature: Supports Redirection
 
   # TODO: Look in to why this actually fails...
   Scenario: A service that redirects to a relative URL
+    Given a remote service that returns 'Service Response'
+    And that service is accessed at the path '/landing_service.html'
+    And the url '/landing/service.html' redirects to the relative path '../landing_service.html'
+    When I call HTTParty#get with '/landing/service.html'
+    Then the return value should match 'Service Response'
 
   Scenario: A service that redirects infinitely
     Given the url '/first.html' redirects to '/second.html'

--- a/features/supports_redirection.feature
+++ b/features/supports_redirection.feature
@@ -12,7 +12,6 @@ Feature: Supports Redirection
     When I call HTTParty#get with '/redirector.html'
     Then the return value should match 'Service Response'
 
-  # TODO: Look in to why this actually fails...
   Scenario: A service that redirects to a relative URL
     Given a remote service that returns 'Service Response'
     And that service is accessed at the path '/landing_service.html'

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -88,15 +88,19 @@ module HTTParty
 
     def uri
       if redirect && path.relative? && path.path[0] != "/"
-        last_uri_host = @last_uri.path.gsub(/[^\/]+$/, "")
+        if path.path.start_with?('./')
+          last_uri_host = @last_uri.path
+        else
+          last_uri_host = @last_uri.path.gsub(/[^\/]+$/, "")
+        end
 
         path.path = "/#{path.path}" if last_uri_host[-1] != "/"
         path.path = last_uri_host + path.path
 
-        # use absolute path [#582]
-        if path.path.include?('/../')
+        if path.path.include?('/../') || path.path.include?('/./')
           path.path = File.expand_path(path.path)
         end
+
       end
 
       if path.relative? && path.host

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -92,6 +92,11 @@ module HTTParty
 
         path.path = "/#{path.path}" if last_uri_host[-1] != "/"
         path.path = last_uri_host + path.path
+
+        # use absolute path [#582]
+        if path.path.include?('/../')
+          path.path = File.expand_path(path.path)
+        end
       end
 
       if path.relative? && path.host

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -664,6 +664,18 @@ RSpec.describe HTTParty::Request do
           expect(response.parsed_response).to eq({"hash" => {"foo" => "bar"}})
         end
 
+        it "redirects to an absolute path if a 300 contains a relative path in the location header" do
+          redirect = stub_response '', 300
+          redirect['location'] = '../bar/baz'
+          ok = stub_response('<hash><bar>baz</bar></hash>', 200)
+          allow(@http).to receive(:request).and_return(redirect, ok)
+          response = @request.perform
+          expect(response.request.base_uri.to_s).to eq("http://api.foo.com")
+          expect(response.request.uri.request_uri).to eq("/bar/baz")
+          expect(response.request.uri.to_s).to eq("http://api.foo.com/bar/baz")
+          expect(response.parsed_response).to eq({"hash" => {"bar" => "baz"}})
+        end
+
         it "handles multiple redirects and relative location headers on different hosts" do
           @request = HTTParty::Request.new(Net::HTTP::Get, 'http://test.com/redirect', format: :xml)
           stub_request(:get, 'http://test.com/redirect')


### PR DESCRIPTION
This is a fix for #582. First time contributor so keen for feedback.