### PR TITLE
Rename cop Lint/HandleExceptions to Lint/SuppressedException

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -15,7 +15,7 @@ Lint/EndAlignment:
   Enabled: false
 
 # Offense count: 1
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: false
 
 # Offense count: 5


### PR DESCRIPTION
Received an error while doing on a project that has httparty dependency.
```bash
rubocop --safe-auto-correct
```
```
Error: The `Lint/HandleExceptions` cop has been renamed to `Lint/SuppressedException`.
(obsolete configuration found in vendor/bundle/ruby/2.6.0/gems/httparty-0.18.0/.rubocop_todo.yml, please update it)
```