### PR TITLE
Redirect with authorization credentials to same host for relative paths

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -299,7 +299,7 @@ module HTTParty
     def handle_host_redirection
       check_duplicate_location_header
       redirect_path = options[:uri_adapter].parse(last_response['location']).normalize
-      return if redirect_path.relative? || path.host == redirect_path.host
+      return if redirect_path.relative? || path.host == redirect_path.host || uri.host == redirect_path.host
       @changed_hosts = true
     end
 

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -1313,6 +1313,20 @@ RSpec.describe HTTParty::Request do
         @request.send(:setup_raw_request)
         expect(@request.instance_variable_get(:@raw_request)['authorization']).to eq(@authorization)
       end
+
+      context 'when uri path is a relative path' do
+        before do
+          @request.path = '/v1'
+          @request.options[:base_uri] = 'http://api.foo.com'
+        end
+
+        it "should send Authorization header when redirecting to the same host" do
+          @redirect['location'] = 'http://api.foo.com/v2'
+          @request.perform
+          @request.send(:setup_raw_request)
+          expect(@request.instance_variable_get(:@raw_request)['authorization']).to eq(@authorization)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
Currently, we can create a valid httparty request with a `base_uri` and a relative path. However, there is an issue where by the request will not be redirected with the http authentication credentials if the request is created this way.

This PR fixes that issue by validating if the host of the `uri` is the same as the host of the `redirect_path`

## Illustration of problem

With the following `Request`:

![image](https://user-images.githubusercontent.com/9844923/81163333-2a569980-8fc1-11ea-9a0b-ad27532ea892.png)


![image](https://user-images.githubusercontent.com/9844923/81162888-7b19c280-8fc0-11ea-9a29-3ce0999544cc.png)

![image](https://user-images.githubusercontent.com/9844923/81163117-d350c480-8fc0-11ea-9a1a-1b5dc3b004a3.png)
