### PR TITLE
Update connection adapter to only trust ssl_ca_*

### DIFF
--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -209,9 +209,11 @@ module HTTParty
           http.verify_mode = OpenSSL::SSL::VERIFY_PEER
           if options[:cert_store]
             http.cert_store = options[:cert_store]
-          else
-            # Use the default cert store by default, i.e. system ca certs
-            http.cert_store = self.class.default_cert_store
+          else 
+            unless options[:ssl_ca_file] or options[:ssl_ca_path]
+              # Use the default cert store by default, i.e. system ca certs unless ssl_ca_file or ssl_ca_path is used
+              http.cert_store = self.class.default_cert_store
+            end
           end
         else
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE


### PR DESCRIPTION
This change modifies httparty's behavior to only trust the system CAs if ssl_ca_file and ssl_ca_path is not provided.

As a user using my own CA, I only want to trust my CA. Not my CA and all the other CAs. 

This change in behavior was introduced in recent version of curl.

Users wanting to trust both can add the system CA to ssl_ca_file or ssl_ca_path. Alternatively, they can (and should) use a different class for each backend they are connecting to.

I didn't provide test cases as the current tests are broken and I couldn't find a way to fix them.