### PR TITLE
Fix #713

### DIFF
--- a/features/steps/httparty_steps.rb
+++ b/features/steps/httparty_steps.rb
@@ -15,6 +15,15 @@ When /^I set my HTTParty header '(.*)' to value '(.*)'$/ do |name, value|
   @request_options[:headers][name] = value
 end
 
+When /I set my HTTParty logger option/ do
+  # TODO: make the IO something portable
+  @request_options[:logger] = Logger.new("/dev/null")
+end
+
+When /I set my HTTParty parser option to a proc/ do
+  @request_options[:parser] = proc { |body| body }
+end
+
 When /I call HTTParty#get with '(.*)'$/ do |url|
   begin
     @response_from_httparty = HTTParty.get("http://#{@host_and_port}#{url}", @request_options)
@@ -45,4 +54,12 @@ When /I call HTTParty#get with '(.*)' and a digest_auth hash:/ do |url, auth_tab
     "http://#{@host_and_port}#{url}",
     digest_auth: { username: h["username"], password: h["password"] }
   )
+end
+
+When /I call Marshal\.dump on the response/ do
+  begin
+    Marshal.dump(@response_from_httparty)
+  rescue TypeError => e
+    @exception_from_httparty = e
+  end
 end

--- a/features/supports_marshalling_with_logger_and_proc.feature
+++ b/features/supports_marshalling_with_logger_and_proc.feature
@@ -1,0 +1,21 @@
+Feature: Supports marshalling with request logger and/or proc parser
+  In order to support caching responses
+  As a developer
+  I want the request to be able to be marshalled if I have set up a custom
+  logger or have a proc as the response parser.
+
+  Scenario: Marshal response with request logger
+    Given a remote service that returns '{ "some": "data" }'
+    And that service is accessed at the path '/somedata.json'
+    When I set my HTTParty logger option
+    And I call HTTParty#get with '/somedata.json'
+    And I call Marshal.dump on the response
+    Then it should not raise a TypeError exception
+
+  Scenario: Marshal response with proc parser
+    Given a remote service that returns '{ "some": "data" }'
+    And that service is accessed at the path '/somedata.json'
+    When I set my HTTParty parser option to a proc
+    And I call HTTParty#get with '/somedata.json'
+    And I call Marshal.dump on the response
+    Then it should not raise a TypeError exception

--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -44,6 +44,11 @@ module HTTParty
       end.flatten.join('&')
     end
 
+    def self._load(data)
+      http_method, path, options = Marshal.load(data)
+      new(http_method, path, options)
+    end
+
     attr_accessor :http_method, :options, :last_response, :redirect, :last_uri
     attr_reader :path
 
@@ -171,6 +176,13 @@ module HTTParty
 
     def raw_body
       @raw_request.body
+    end
+
+    def _dump(_level)
+      opts = options.dup
+      opts.delete(:logger)
+      opts.delete(:parser) if opts[:parser] && opts[:parser].is_a?(Proc)
+      Marshal.dump([http_method, path, opts])
     end
 
     private

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -1387,4 +1387,13 @@ RSpec.describe HTTParty::Request do
       expect(request.instance_variable_get(:@raw_request).decode_content).to eq(true)
     end
   end
+
+  describe "marshalling" do
+    it "properly marshals the request object" do
+      marshalled = Marshal.load(Marshal.dump(@request))
+      expect(marshalled.http_method).to eq @request.http_method
+      expect(marshalled.path).to eq @request.path
+      expect(marshalled.options).to eq @request.options
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes the issue(s) described in #713. To fix the logger option
issue, I simply delete `Request.options[:logger]` when dumping. To fix
the proc parser issue, I delete `Request.options[:parser]` if and only
if `Request.options[:logger]` is a proc. If `Request.options[:logger]`
is a regular class, `Marshal.dump` should proceed as normal. This should
not affect the `Marshal.dump` behavior described in issue #143 and fixed
by PR #618.

I have added a feature spec to make sure marshalling the request
works as intended, as well as a unit test to ensure
`Marshal.load(Marshal.dump(req))` works as it should.

I would love to hear your feedback on this. I'm not crazy about simply deleting the `:logger` and `:parser` options, but I'm not sure how else to handle it. Thanks in advance.