### PR TITLE
switch :pem option to to OpenSSL::PKey.read to support other algorithms

### DIFF
--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -223,7 +223,7 @@ module HTTParty
         # Note: options[:pem] must contain the content of a PEM file having the private key appended
         if options[:pem]
           http.cert = OpenSSL::X509::Certificate.new(options[:pem])
-          http.key = OpenSSL::PKey::RSA.new(options[:pem], options[:pem_password])
+          http.key = OpenSSL::PKey.read(options[:pem], options[:pem_password])
           http.verify_mode = verify_ssl_certificate? ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
         end
 

--- a/spec/httparty/connection_adapter_spec.rb
+++ b/spec/httparty/connection_adapter_spec.rb
@@ -558,7 +558,7 @@ RSpec.describe HTTParty::ConnectionAdapter do
 
           before do
             expect(OpenSSL::X509::Certificate).to receive(:new).with(pem).and_return(cert)
-            expect(OpenSSL::PKey::RSA).to receive(:new).with(pem, "password").and_return(key)
+            expect(OpenSSL::PKey).to receive(:read).with(pem, "password").and_return(key)
           end
 
           it "uses the provided PEM certificate" do


### PR DESCRIPTION
I just threw this together but it seems to work, specs pass. Use case is connecting to Kubernetes 1.19 cluster which uses an EC key. Original code's call to `OpenSSL::PKey::RSA.new` on the key raises `OpenSSL::PKey::RSAError: Neither PUB key nor PRIV key: nested asn1 error`

`OpenSSL::PKey::EC.new` works for the EC key, but from the docs it appears `OpenSSL::PKey.read` is an agnostic solution that will auto-return the right PKey type so should work for RSA/DSA/EC?