### PR TITLE
Fix method call in spec for Ruby 3.0.0

### DIFF
--- a/spec/httparty/request/body_spec.rb
+++ b/spec/httparty/request/body_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe HTTParty::Request::Body do
   describe '#call' do
     let(:options) { {} }
 
-    subject { described_class.new(params, options).call }
+    subject { described_class.new(params, **options).call }
 
     context 'when params is string' do
       let(:params) { 'name=Bob%20Jones' }


### PR DESCRIPTION
Ruby 3.0.0 requires transforming a hash to named parameters for method calls. This fix gets all tests to pass for Ruby 3.0.0 as well as older versions of Ruby (I tested 2.6.3).