### PR TITLE
Fix typo in exceptions.rb docs

### DIFF
--- a/lib/httparty/exceptions.rb
+++ b/lib/httparty/exceptions.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module HTTParty
-  # @abstact Exceptions raised by HTTParty inherit from Error
+  # @abstract Exceptions raised by HTTParty inherit from Error
   class Error < StandardError; end
 
   # Exception raised when you attempt to set a non-existent format


### PR DESCRIPTION
The title says it all - just fixing a minor typo I noticed while reading through the source code.