### PR TITLE
Add RubyDoc link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ httparty "https://api.stackexchange.com/2.2/questions?site=stackoverflow"
 ## Help and Docs
 
 * [Docs](https://github.com/jnunemaker/httparty/tree/master/docs)
+* [RubyDoc](https://www.rubydoc.info/github/jnunemaker/httparty)
 * https://groups.google.com/forum/#!forum/httparty-gem
 * https://www.rubydoc.info/github/jnunemaker/httparty
 * http://stackoverflow.com/questions/tagged/httparty


### PR DESCRIPTION
Hi 👋 I always struggle to remember things like "how do I check the response status again?" and have to poke through the examples directory in hopes there might be something relevant. I thought that linking to the RubyDoc might help.