### PR TITLE
Better handling of Accept-Encoding / Content-Encoding decompression (fixes #562)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -104,3 +104,68 @@ class Client
   end
 end
 ```
+
+### HTTP Compression
+
+The `Accept-Encoding` request header and `Content-Encoding` response header
+are used to control compression (gzip, etc.) over the wire. Refer to
+[RFC-2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html) for details.
+(For clarity: these headers are **not** used for character encoding i.e. `utf-8`
+which is specified in the `Accept` and `Content-Type` headers.)
+
+Unless you have specific requirements otherwise, we recommend to **not** set
+set the `Accept-Encoding` header on HTTParty requests. In this case, `Net::HTTP`
+will set a sensible default compression scheme and automatically decompress the response.
+
+If you explicitly set `Accept-Encoding`, there be dragons:
+
+* If the HTTP response `Content-Encoding` received on the wire is `gzip` or `deflate`,
+  `Net::HTTP` will automatically decompress it, and will omit `Content-Encoding`
+  from your `HTTParty::Response` headers.
+
+* For encodings `br` (Brotli) or `compress` (LZW), HTTParty will automatically
+  decompress if you include the `brotli` or `ruby-lzws` gems respectively into your project.
+  **Warning:** Support for these encodings is experimental and not fully battle-tested.
+  Similar to above, if decompression succeeds, `Content-Encoding` will be omitted
+  from your `HTTParty::Response` headers.
+
+* For other encodings, `HTTParty::Response#body` will return the raw uncompressed byte string,
+  and you'll need to inspect the `Content-Encoding` response header and decompress it yourself.
+  In this case, `HTTParty::Response#parsed_response` will be `nil`.
+
+* Lastly, you may use the `skip_decompression` option to disable all automatic decompression
+  and always get `HTTParty::Response#body` in its raw form along with the `Content-Encoding` header.
+
+```ruby
+# Accept-Encoding=gzip,deflate can be safely assumed to be auto-decompressed
+
+res = HTTParty.get('https://example.com/test.json', headers: { 'Accept-Encoding' => 'gzip,deflate,identity' })
+JSON.parse(res.body) # safe
+
+
+# Accept-Encoding=br,compress requires third-party gems
+
+require 'brotli'
+require 'lzws'
+res = HTTParty.get('https://example.com/test.json', headers: { 'Accept-Encoding' => 'br,compress' })
+JSON.parse(res.body)
+
+
+# Accept-Encoding=* may return unhandled Content-Encoding
+
+res = HTTParty.get('https://example.com/test.json', headers: { 'Accept-Encoding' => '*' })
+encoding = res.headers['Content-Encoding']
+if encoding
+JSON.parse(your_decompression_handling(res.body, encoding))
+else
+# Content-Encoding not present implies decompressed
+JSON.parse(res.body)
+end
+
+
+# Gimme the raw data!
+
+res = HTTParty.get('https://example.com/test.json', skip_decompression: true)
+encoding = res.headers['Content-Encoding']
+JSON.parse(your_decompression_handling(res.body, encoding))
+```

--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -18,6 +18,7 @@ require 'httparty/connection_adapter'
 require 'httparty/logger/logger'
 require 'httparty/request/body'
 require 'httparty/response_fragment'
+require 'httparty/decompressor'
 require 'httparty/text_encoder'
 require 'httparty/headers_processor'
 
@@ -399,6 +400,22 @@ module HTTParty
     #   end
     def ssl_version(version)
       default_options[:ssl_version] = version
+    end
+
+    # Deactivate automatic decompression of the response body.
+    # This will require you to explicitly handle body decompression
+    # by inspecting the Content-Encoding response header.
+    #
+    # Refer to docs/README.md "HTTP Compression" section for
+    # further details.
+    #
+    # @example
+    #   class Foo
+    #     include HTTParty
+    #     skip_decompression
+    #   end
+    def skip_decompression(value = true)
+      default_options[:skip_decompression] = !!value
     end
 
     # Allows setting of SSL ciphers to use.  This only works in Ruby 1.9+.

--- a/lib/httparty/decompressor.rb
+++ b/lib/httparty/decompressor.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module HTTParty
+  # Decompresses the response body based on the Content-Encoding header.
+  #
+  # Net::HTTP automatically decompresses Content-Encoding values "gzip" and "deflate".
+  # This class will handle "br" (Brotli) and "compress" (LZW) if the requisite
+  # gems are installed. Otherwise, it returns nil if the body data cannot be
+  # decompressed.
+  #
+  # @abstract Read the HTTP Compression section for more information.
+  class Decompressor
+
+    # "gzip" and "deflate" are handled by Net::HTTP
+    # hence they do not need to be handled by HTTParty
+    SupportedEncodings = {
+      'none'     => :none,
+      'identity' => :none,
+      'br'       => :brotli,
+      'compress' => :lzw
+    }.freeze
+
+    # The response body of the request
+    # @return [String]
+    attr_reader :body
+
+    # The Content-Encoding algorithm used to encode the body
+    # @return [Symbol] e.g. :gzip
+    attr_reader :encoding
+
+    # @param [String] body - the response body of the request
+    # @param [Symbol] encoding - the Content-Encoding algorithm used to encode the body
+    def initialize(body, encoding)
+      @body = body
+      @encoding = encoding
+    end
+
+    # Perform decompression on the response body
+    # @return [String] the decompressed body
+    # @return [nil] when the response body is nil or cannot decompressed
+    def decompress
+      return nil if body.nil?
+      return body if encoding.nil? || encoding.strip.empty?
+
+      if supports_encoding?
+        decompress_supported_encoding
+      else
+        nil
+      end
+    end
+
+    protected
+
+    def supports_encoding?
+      SupportedEncodings.keys.include?(encoding)
+    end
+
+    def decompress_supported_encoding
+      method = SupportedEncodings[encoding]
+      if respond_to?(method, true)
+        send(method)
+      else
+        raise NotImplementedError, "#{self.class.name} has not implemented a decompression method for #{encoding.inspect} encoding."
+      end
+    end
+
+    def none
+      body
+    end
+
+    def brotli
+      return nil unless defined?(::Brotli)
+      begin
+        ::Brotli.inflate(body)
+      rescue StandardError
+        nil
+      end
+    end
+
+    def lzw
+      begin
+        if defined?(::LZWS::String)
+          ::LZWS::String.decompress(body)
+        elsif defined?(::LZW::Simple)
+          ::LZW::Simple.new.decompress(body)
+        end
+      rescue StandardError
+        nil
+      end
+    end
+  end
+end

--- a/lib/httparty/parser.rb
+++ b/lib/httparty/parser.rb
@@ -144,9 +144,11 @@ module HTTParty
     end
 
     def parse_supported_format
-      send(format)
-    rescue NoMethodError => e
-      raise NotImplementedError, "#{self.class.name} has not implemented a parsing method for the #{format.inspect} format.", e.backtrace
+      if respond_to?(format, true)
+        send(format)
+      else
+        raise NotImplementedError, "#{self.class.name} has not implemented a parsing method for the #{format.inspect} format."
+      end
     end
   end
 end

--- a/spec/httparty/decompressor_spec.rb
+++ b/spec/httparty/decompressor_spec.rb
@@ -1,0 +1,135 @@
+require 'spec_helper'
+
+RSpec.describe HTTParty::Decompressor do
+  describe '.SupportedEncodings' do
+    it 'returns a hash' do
+      expect(HTTParty::Decompressor::SupportedEncodings).to be_instance_of(Hash)
+    end
+  end
+
+  describe '#decompress' do
+    let(:body) { 'body' }
+    let(:encoding) { 'none' }
+    let(:decompressor) { described_class.new(body, encoding) }
+    subject { decompressor.decompress }
+
+    shared_examples 'returns nil' do
+      it { expect(subject).to be_nil }
+    end
+
+    shared_examples 'returns the body' do
+      it { expect(subject).to eq 'body' }
+    end
+
+    context 'when body is nil' do
+      let(:body) { nil }
+      it_behaves_like 'returns nil'
+    end
+
+    context 'when body is blank' do
+      let(:body) { ' ' }
+      it { expect(subject).to eq ' ' }
+    end
+
+    context 'when encoding is nil' do
+      let(:encoding) { nil }
+      it_behaves_like 'returns the body'
+    end
+
+    context 'when encoding is blank' do
+      let(:encoding) { ' ' }
+      it_behaves_like 'returns the body'
+    end
+
+    context 'when encoding is "none"' do
+      let(:encoding) { 'none' }
+      it_behaves_like 'returns the body'
+    end
+
+    context 'when encoding is "identity"' do
+      let(:encoding) { 'identity' }
+      it_behaves_like 'returns the body'
+    end
+
+    context 'when encoding is unsupported' do
+      let(:encoding) { 'invalid' }
+      it_behaves_like 'returns nil'
+    end
+
+    context 'when encoding is "br"' do
+      let(:encoding) { 'br' }
+
+      context 'when brotli gem not included' do
+        it_behaves_like 'returns nil'
+      end
+
+      context 'when brotli included' do
+        before do
+          dbl = double('Brotli')
+          expect(dbl).to receive(:inflate).with('body').and_return('foobar')
+          stub_const('Brotli', dbl)
+        end
+
+        it { expect(subject).to eq 'foobar' }
+      end
+
+      context 'when brotli raises error' do
+        before do
+          dbl = double('brotli')
+          expect(dbl).to receive(:inflate).with('body') { raise RuntimeError.new('brotli error') }
+          stub_const('Brotli', dbl)
+        end
+
+        it { expect(subject).to eq nil }
+      end
+    end
+
+    context 'when encoding is "compress"' do
+      let(:encoding) { 'compress' }
+
+      context 'when LZW gem not included' do
+        it_behaves_like 'returns nil'
+      end
+
+      context 'when ruby-lzws included' do
+        before do
+          dbl = double('lzws')
+          expect(dbl).to receive(:decompress).with('body').and_return('foobar')
+          stub_const('LZWS::String', dbl)
+        end
+
+        it { expect(subject).to eq 'foobar' }
+      end
+
+      context 'when ruby-lzws raises error' do
+        before do
+          dbl = double('lzws')
+          expect(dbl).to receive(:decompress).with('body') { raise RuntimeError.new('brotli error') }
+          stub_const('LZWS::String', dbl)
+        end
+
+        it { expect(subject).to eq nil }
+      end
+
+      context 'when compress-lzw included' do
+        before do
+          dbl2 = double('lzw2')
+          dbl = double('lzw1', new: dbl2)
+          expect(dbl2).to receive(:decompress).with('body').and_return('foobar')
+          stub_const('LZW::Simple', dbl)
+        end
+
+        it { expect(subject).to eq 'foobar' }
+      end
+
+      context 'when compress-lzw raises error' do
+        before do
+          dbl2 = double('lzw2')
+          dbl = double('lzw1', new: dbl2)
+          expect(dbl2).to receive(:decompress).with('body') { raise RuntimeError.new('brotli error') }
+          stub_const('LZW::Simple', dbl)
+        end
+      end
+    end
+  end
+end

--- a/spec/httparty/ssl_spec.rb
+++ b/spec/httparty/ssl_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe HTTParty::Request do
 
     it "should work when using ssl_ca_path with a certificate authority" do
       http = Net::HTTP.new('www.google.com', 443)
-      response = double(Net::HTTPResponse, :[] => '', body: '', to_hash: {})
+      response = double(Net::HTTPResponse, :[] => '', body: '', to_hash: {}, delete: nil)
       allow(http).to receive(:request).and_return(response)
       expect(Net::HTTP).to receive(:new).with('www.google.com', 443).and_return(http)
       expect(http).to receive(:ca_path=).with('/foo/bar')

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -876,6 +876,7 @@ RSpec.describe HTTParty do
       before do
         stub_chunked_http_response_with([chunk], options) do |response|
           allow(response).to receive(:[]).with('content-type').and_return('text/plain; charset = "utf-8"')
+          allow(response).to receive(:[]).with('content-encoding').and_return(nil)
         end
       end
 


### PR DESCRIPTION
### Summary

Better handling of `Accept-Encoding` / `Content-Encoding` decompression:
1. By default, let `Net::HTTP` always do decompression, if it can.
2. Add support to decompress `"br"` ([Brotli](https://en.wikipedia.org/wiki/Brotli)) and `"compress"` (LZW) if the required gems are present. These are not supported by `Net::HTTP`
3. Add `:skip_decompression` option to disable both Net::HTTP and HTTParty decompression (i.e. 1 and 2 above)
4. Add "HTTP Compression" section to docs/README.md

This fixes #562 and reverts some `Accept-Encoding` behavior in v0.18.x back to how it was in v0.17.3 and prior.

### More Background

PR #678, released in v0.18.0, introduced undesirable behavior which broke my app in production.

* In v0.17.3 and prior, you could set the `Accept-Encoding` header (e.g. `gzip`, etc.) in a request, and `Net::HTTP` would automatically handle decompression the response body in most cases.
* In v0.18.0+, as a result of PR #678, when setting `Accept-Encoding`, `Net::HTTP` no longer performs automatic decompression. This means your `response.body` will be a gzipped byte-string, and `JSON.parse(request.body)` will fail. In my case, it actually failed with a process segfault because I use a C-based native JSON parsing lib called [Oj](https://github.com/ohler55/oj).

### The Way Forward

The "happy path" for the 99.9% majority of users to [party on](https://www.youtube.com/watch?v=MA5rg_LIcWY) is to have Net::HTTP auto-decompress whenever it can, even if you set the `Accept-Encoding` header. The 0.1% of purist users out there can use the new `:skip_decompression` option which disables auto-decompression in all cases, meaning you'll always get the raw response and the `Content-Encoding` header so you can roll your own decompression.

This change is fully backward compatible with versions prior to v0.18.0 (i.e. it fixes the 0.17.3 --> 0.18.0 breakage), and mostly compatible with v0.18.0+, with the caveat that users using `Accept-Encoding` may get an uncompressed response when they previous got a compressed one. It should be released as a minor bump `0.19.0`