### PR TITLE
CI: use ruby/setup-ruby + bundler-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,20 +9,10 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
-      - name: Do some action caching
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gem-
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Install bundler
-        run: gem install bundler
-      - name: Run bundler
-        run: bundle install --jobs 4 --retry 3
+          bundler-cache: true # Run "bundle install", and cache the result automatically.
       - name: Run Rake
         run: bundle exec rake


### PR DESCRIPTION
This PR leverages the bundler-cache feature of the Ruby-maintained Action setup-ruby.

[See ruby/setup-ruby](https://github.com/ruby/setup-ruby/blob/master/action.yml) for more information.