### PR TITLE
CI: Add "3.0" to build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
+          - '3.0' # Quoted, to avoid YAML float 3.0 interplated to "3"
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2


### PR DESCRIPTION
This is a very small change, add Ruby 3.0 to build matrix.


...but which avoids a Float-to-String loss of characters.

An example (not from this project) of what it can look like before this change, in this picture:

<img width="376" alt="bild" src="https://user-images.githubusercontent.com/211/119782378-6ad6cd00-becc-11eb-9e13-9a425adaa054.png">

Read more details, if you like: https://github.com/actions/runner/issues/849