### PR TITLE
Adds Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
           - 2.6
           - 2.7
           - '3.0' # Quoted, to avoid YAML float 3.0 interplated to "3"
+          - 3.1
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.simplecov
+++ b/.simplecov
@@ -1,1 +1,0 @@
-SimpleCov.start "test_frameworks"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require "simplecov"
 SimpleCov.start
-require 'pry'
 
 require "httparty"
 require 'webmock/rspec'


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.  It includes two other changes:

1. Removes the .simplecov file, which causes an error on Ruby 3.1 (coverage attempts to start twice)
2. Removes the require "pry", as pry is not going to be the Ruby debugger going forward