### PR TITLE
Add Thread Safety checks and patches using `rubocop` and `rubocop-thread_safety`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,5 @@ jobs:
           bundler-cache: true # Run "bundle install", and cache the result automatically.
       - name: Run Rake
         run: bundle exec rake
+      - name: Run ThreadSafety Check
+        run: bundle exec rubocop --only ThreadSafety

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,18 +9,18 @@ Style/StringLiterals:
 # Offense count: 327
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces, SupportedStyles.
-Style/SpaceInsideHashLiteralBraces:
+Layout/SpaceInsideHashLiteralBraces:
   Enabled: false
 
 # Offense count: 33
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, EnforcedStyleForEmptyBraces, SpaceBeforeBlockParameters.
-Style/SpaceInsideBlockBraces:
+Layout/SpaceInsideBlockBraces:
   Enabled: false
 
 # Offense count: 1
 # Cop supports --auto-correct.
-Style/SpaceBeforeSemicolon:
+Layout/SpaceBeforeSemicolon:
   Enabled: false
 
 # Offense count: 20
@@ -43,12 +43,6 @@ Style/PerlBackrefs:
 # Cop supports --auto-correct.
 # Configuration parameters: AllowAsExpressionSeparator.
 Style/Semicolon:
-  Enabled: false
-
-# Offense count: 77
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-Style/BracesAroundHashParameters:
   Enabled: false
 
 # Offense count: 36
@@ -78,12 +72,6 @@ Lint/UnusedBlockArgument:
 
 # Offense count: 1
 Lint/Void:
-  Enabled: false
-
-# Offense count: 22
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-Style/IndentHash:
   Enabled: false
 
 # Offense count: 7

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,8 @@ require:
 #Thread Safety
 ThreadSafety:
   Enabled: true
+  Exclude:
+    - 'spec/**/*'
 
 # Offense count: 963
 # Cop supports --auto-correct.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,12 @@
 inherit_from: .rubocop_todo.yml
 
+require:
+  - rubocop-thread_safety
+
+#Thread Safety
+ThreadSafety:
+  Enabled: true
+
 # Offense count: 963
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,7 +11,7 @@ Lint/AmbiguousRegexpLiteral:
 
 # Offense count: 1
 # Configuration parameters: AlignWith, SupportedStyles.
-Lint/EndAlignment:
+Layout/EndAlignment:
   Enabled: false
 
 # Offense count: 1
@@ -37,7 +37,7 @@ Metrics/CyclomaticComplexity:
 
 # Offense count: 332
 # Configuration parameters: AllowURI, URISchemes.
-Metrics/LineLength:
+Layout/LineLength:
   Max: 266
 
 # Offense count: 17
@@ -50,7 +50,7 @@ Metrics/PerceivedComplexity:
   Max: 20
 
 # Offense count: 1
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Enabled: false
 
 # Offense count: 1
@@ -69,7 +69,7 @@ Style/CaseEquality:
 
 # Offense count: 3
 # Configuration parameters: IndentWhenRelativeTo, SupportedStyles, IndentOneStep.
-Style/CaseIndentation:
+Layout/CaseIndentation:
   Enabled: false
 
 # Offense count: 4
@@ -78,7 +78,7 @@ Style/ClassAndModuleChildren:
   Enabled: false
 
 # Offense count: 7
-Style/ConstantName:
+Naming/ConstantName:
   Enabled: false
 
 # Offense count: 2
@@ -87,13 +87,13 @@ Style/EachWithObject:
 
 # Offense count: 2
 # Cop supports --auto-correct.
-Style/ElseAlignment:
+Layout/ElseAlignment:
   Enabled: false
 
 # Offense count: 3
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.
-Style/FirstParameterIndentation:
+Layout/FirstParameterIndentation:
   Enabled: false
 
 # Offense count: 2

--- a/Gemfile
+++ b/Gemfile
@@ -21,4 +21,6 @@ end
 
 group :development, :test do
   gem 'pry'
+  gem 'rubocop', require: false
+  gem 'rubocop-thread_safety', require: false
 end

--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -81,7 +81,7 @@ module HTTParty
     end
 
     def self.default_cert_store
-      @default_cert_store ||= OpenSSL::X509::Store.new.tap do |cert_store|
+      Thread.current[:httparty_default_cert_store] ||= OpenSSL::X509::Store.new.tap do |cert_store|
         cert_store.set_default_paths
       end
     end

--- a/lib/httparty/logger/logger.rb
+++ b/lib/httparty/logger/logger.rb
@@ -7,7 +7,7 @@ require 'httparty/logger/logstash_formatter'
 module HTTParty
   module Logger
     def self.formatters
-      @formatters ||= {
+      Thread.current[:httparty_logger_formatters] ||= {
         :curl => Logger::CurlFormatter,
         :apache => Logger::ApacheFormatter,
         :logstash => Logger::LogstashFormatter,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,7 +39,7 @@ RSpec.configure do |config|
 
   config.before(:each) do
     # Reset default_cert_store cache
-    HTTParty::ConnectionAdapter.instance_variable_set(:@default_cert_store, nil)
+    Thread.current[:httparty_default_cert_store] = nil
   end
 
   Kernel.srand config.seed


### PR DESCRIPTION
1. Added https://github.com/covermymeds/rubocop-thread_safety to help identify thread safety issues
2. Updated `.rubocop*` to remove errors & warnings so that Rubocop would run
3. Enabled `ThreadSafety` checks for Rubocop, ignoring `spec/**/*`
4. Added a step in the Github action to run the Rubocop thread safety check
5. Updated `ConnectionAdapter.default_cert_store` & `Logger.formatters` to use thread variables

I tried refactoring `ModuleInheritableAttributes` to try not to use instance variables on the class, but couldn't figure it out. Any help would be super appreciated!