### PR TITLE
Do not dup nonfrozen string on download (Fix memory leak)

### DIFF
--- a/lib/httparty/text_encoder.rb
+++ b/lib/httparty/text_encoder.rb
@@ -5,7 +5,7 @@ module HTTParty
     attr_reader :text, :content_type, :assume_utf16_is_big_endian
 
     def initialize(text, assume_utf16_is_big_endian: true, content_type: nil)
-      @text = text.dup
+      @text = +text
       @content_type = content_type
       @assume_utf16_is_big_endian = assume_utf16_is_big_endian
     end


### PR DESCRIPTION
`dup` was introduced [here](https://github.com/jnunemaker/httparty/commit/d90a62f8da6f5f9c01dba1644dd1591a2f6ebc81) to avoid problems where response body was frozen. Unfortunately, it came with a huge memory penalty and caused a memory leak

Following https://gitlab.com/gitlab-org/gitlab/-/issues/29196 and using [provided benchmark](https://gitlab.com/brodock/benchmark-http-clients) here are the results (GC was disabled)

Before
```
rake download

HTTParty: 221.54 MB
```
After
```
rake download

HTTParty: 15.67 MB
```

---

Memory leak during upload was fixed with https://github.com/jnunemaker/httparty/pull/711