### PR TITLE
Remove redundant require

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -2,7 +2,6 @@
 
 require 'pathname'
 require 'net/http'
-require 'net/https'
 require 'uri'
 require 'zlib'
 require 'multi_xml'


### PR DESCRIPTION
net/https is no longer needed since Ruby 2, according to the docs.

https://docs.ruby-lang.org/en/2.0.0/Net/HTTP.html#class-Net::HTTP-label-HTTPS