### PR TITLE
Add docs on JSON post, put and patch requests

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,20 @@ response = HTTParty.get('http://example.com', format: :plain)
 JSON.parse response, symbolize_names: true
 ```
 
+## Posting JSON
+When using Content Type `application/json` with `POST`, `PUT` or `PATCH` requests, the body should be a string of valid JSON:
+
+```ruby
+# With written JSON
+HTTParty.post('http://example.com', body: "{\"foo\":\"bar\"}", headers: { 'Content-Type' => 'application/json' })
+
+# Using JSON.generate
+HTTParty.post('http://example.com', body: JSON.generate({ foo: 'bar' }), headers: { 'Content-Type' => 'application/json' })
+
+# Using object.to_json
+HTTParty.post('http://example.com', body: { foo: 'bar' }.to_json, headers: { 'Content-Type' => 'application/json' })
+```
+
 ## Working with SSL
 
 You can use this guide to work with SSL certificates.


### PR DESCRIPTION
Addresses https://github.com/jnunemaker/httparty/issues/743

This change adds docs regarding how to send data in JSON format. Users are often<sup>[1][2]</sup> on how to format JSON data to use in POST, PUT and PATCH requests. This adds simple examples on how to do so.

1: https://stackoverflow.com/questions/7455744/post-json-to-api-using-rails-and-httparty
2: https://github.com/jnunemaker/httparty/issues/743