### PR TITLE
Suggestion: Replace `mime-types` with `mini_mime` for content type lookup

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ## unreleased
 
 * Fix request marshaling (https://github.com/jnunemaker/httparty/pull/767)
+* [Replace `mime-types` with `mini_mime`](https://github.com/jnunemaker/httparty/pull/769)
 
 ## 0.20.0
 

--- a/httparty.gemspec
+++ b/httparty.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = '>= 2.3.0'
 
   s.add_dependency 'multi_xml', ">= 0.5.2"
-  s.add_dependency('mime-types', "~> 3.0")
+  s.add_dependency 'mini_mime', ">= 1.0.0"
 
   # If this line is removed, all hard partying will cease.
   s.post_install_message = "When you HTTParty, you must party hard!"

--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -5,7 +5,7 @@ require 'net/http'
 require 'uri'
 require 'zlib'
 require 'multi_xml'
-require 'mime/types'
+require 'mini_mime'
 require 'json'
 require 'csv'
 

--- a/lib/httparty/request/body.rb
+++ b/lib/httparty/request/body.rb
@@ -84,8 +84,8 @@ module HTTParty
 
       def content_type(object)
         return object.content_type if object.respond_to?(:content_type)
-        mime = MIME::Types.type_for(object.path)
-        mime.empty? ? 'application/octet-stream' : mime[0].content_type
+        mime = MiniMime.lookup_by_filename(object.path)
+        mime ? mime.content_type : 'application/octet-stream'
       end
 
       def file_name(object)


### PR DESCRIPTION
`mini_mime` is a minimal mime type library that's more performant and less memory hungry.
https://github.com/discourse/mini_mime

It has replaced `mime-types` in the `mail` gem: (which is a dependency of `actionmailer`, and by extension, `rails`)
https://github.com/mikel/mail/pull/1059

As well as `capybara`:
https://github.com/teamcapybara/capybara/pull/1884

Which also means using it as a dependency of `httparty` would be able to reuse the same dependency that should be already available in most Rails apps, instead of pulling in an extra `mime-types` dependency.

The change in code is pretty straightforward, the same one made by the capybara PR linked above.