### PR TITLE
Support extra chain cert

### DIFF
--- a/.github/workflows/review_buddy.yml
+++ b/.github/workflows/review_buddy.yml
@@ -1,0 +1,17 @@
+on: [pull_request]
+
+name: Review Buddy
+
+jobs:
+  chatgpt_comment:
+    runs-on: ubuntu-latest
+    name: Let ChatGPT review on your PR.
+    steps:
+      - name: ChatGPT Review
+        uses: aw-square/review-buddy@main
+        id: chatgpt
+        with:
+          number: ${{ github.event.pull_request.number }}
+          sessionToken: ${{ secrets.CHATGPT_SESSION_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This change is to add extra chain cert support:

Currently, httparty does not support having multiple certs in the pem option. The only way to pass in multiple certs is to use a ca_file and this pull request will add support to passing multiple certs without the need of a file.