### PR TITLE
Clear body when redirecting to a GET 

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -376,6 +376,7 @@ module HTTParty
       options[:body] = nil
       @raw_request.body = nil
     end
+
     def capture_cookies(response)
       return unless response['Set-Cookie']
       cookies_hash = HTTParty::CookieHash.new

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -928,6 +928,14 @@ RSpec.describe HTTParty::Request do
           expect(@request.http_method).to eq(Net::HTTP::Delete)
         end
 
+        it 'should clear the body before resulting GET requests' do
+          @request.http_method = Net::HTTP::Post
+          @request.options[:body] = { text: 'something' }
+          expect(@request.perform.parsed_response).to eq({"hash" => {"foo" => "bar"}})
+          expect(@request.http_method).to eq(Net::HTTP::Get)
+          expect(@request.options[:body]).to be_nil
+        end
+
         it 'should log the redirection' do
           logger_double = double
           expect(logger_double).to receive(:info).twice


### PR DESCRIPTION
Problem: Ran into a web application firewall that was blocking requests because the originating POST body was retained and transmitted upon redirection. 

Solution: When redirecting, clear the body if the subsequent request is a GET


Note: Also extracted a method to keep the handle_response method more concise and cohesive IMHO