### PR TITLE
Extract request building method

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -591,6 +591,13 @@ module HTTParty
       perform_request Net::HTTP::Unlock, path, options, &block
     end
 
+    def build_request(http_method, path, options = {})
+      options = ModuleInheritableAttributes.hash_deep_dup(default_options).merge(options)
+      HeadersProcessor.new(headers, options).call
+      process_cookies(options)
+      Request.new(http_method, path, options)
+    end
+
     attr_reader :default_options
 
     private
@@ -606,10 +613,7 @@ module HTTParty
     end
 
     def perform_request(http_method, path, options, &block) #:nodoc:
-      options = ModuleInheritableAttributes.hash_deep_dup(default_options).merge(options)
-      HeadersProcessor.new(headers, options).call
-      process_cookies(options)
-      Request.new(http_method, path, options).perform(&block)
+      build_request(http_method, path, options).perform(&block)
     end
 
     def process_cookies(options) #:nodoc:
@@ -675,6 +679,10 @@ module HTTParty
 
   def self.options(*args, &block)
     Basement.options(*args, &block)
+  end
+
+  def self.build_request(*args, &block)
+    Basement.build_request(*args, &block)
   end
 end
 

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -970,4 +970,13 @@ RSpec.describe HTTParty do
       end.to raise_error(URI::InvalidURIError)
     end
   end
+
+  describe "#build_request" do
+    it "should build a request object" do
+      stub_http_response_with('example.html')
+      request = HTTParty.build_request(Net::HTTP::Get, "http://www.example.com")
+      expect(request).to be_a(HTTParty::Request)
+      expect(request.perform.parsed_response).to eq(file_fixture('example.html'))
+    end
+  end
 end


### PR DESCRIPTION
I'm writing a small extension for HTTParty to add [AWS Signature V4](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html) on HTTParty requests. This is achieved by adding computed headers to an existing request object based on its attributes like HTTP method, URL and body. Currently request object is not exposed, so, I end up building a request object and then signing it:
```ruby
# current pseudo-code
class Client
  def self.foo(body)
    sign_v4(Net::HTTP::Post, "/foo", {body:}).perform
  end

  def self.sign_v4(http_method, path, options = {})
    # build request
    options = ModuleInheritableAttributes.hash_deep_dup(default_options).merge(options)
    HeadersProcessor.new(headers, options).call
    process_cookies(options)
    request = Request.new(http_method, path, options)

    # sign request
    signature = Aws::Sigv4::Signer.new.sign_request(http_method:, url:, body:)

    request.options[:headers] ||= {}
    request.options[:headers].merge!(signature.headers)

    request
  end
end
```

As you can see, I ended up copy/pasting the contents of `perform_request`. With the proposed extraction of `build_request` I can write a bit more concise code without having to dig into HTTParty internals:
```ruby
# pseudo-code after this PR
class Client
  def self.foo(body)
    request = build_request(Net::HTTP::Post, "/foo", {body:})
    sign_v4(request).perform
  end

  def self.sign_v4(request)
    # sign request
    signature = Aws::Sigv4::Signer.new.sign_request(
      http_method: request.http_method,
      url: request.url,
      body: request.options[:body]
    )

    request.options[:headers] ||= {}
    request.options[:headers].merge!(signature.headers)

    request
  end
end
```

It's a minor refactor, but would make writing such extension much simpler and without worrying too much about HTTParty internals on how the request is built.