### PR TITLE
Add csv gem as dependency

### DIFF
--- a/httparty.gemspec
+++ b/httparty.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version     = '>= 2.3.0'
 
+  s.add_dependency 'csv'
   s.add_dependency 'multi_xml', ">= 0.5.2"
   s.add_dependency 'mini_mime', ">= 1.0.0"
 


### PR DESCRIPTION
csv has been bundled as a gem, and will be removed from the stdlib from ruby 3.4.0

This patch will fix following warning with Ruby 3.3.0
```
warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of httparty-0.21.0 to add csv into its gemspec.
```