### PR TITLE
CI against Ruby 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           - '3.0' # Quoted, to avoid YAML float 3.0 interplated to "3"
           - 3.1
           - 3.2
+          - 3.3
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds Ruby 3.3 to the CI matrix to ensure `httparty` works with Ruby 3.3.