### PR TITLE
Add support for including extra_chain_cert with p12

### DIFF
--- a/lib/httparty.rb
+++ b/lib/httparty.rb
@@ -353,6 +353,11 @@ module HTTParty
       default_options[:p12_password] = password
     end
 
+    # Allow using a full certificate chain (http.extra_chain_cert)
+    def extra_chain_cert(value = false)
+      default_options[:extra_chain_cert] = value
+    end
+
     # Override the way query strings are normalized.
     # Helpful for overriding the default rails normalization of Array queries.
     #

--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -233,7 +233,8 @@ module HTTParty
         end
 
         # Include full certificate chain
-        if options[:extra_chain_cert] && options[:p12]
+        # Only Ruby 3.0+
+        if options[:extra_chain_cert] && options[:p12] && http.respond_to?(:extra_chain_cert=)
           http.extra_chain_cert = [p12.certificate] + p12.ca_certs
         end
       end

--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -231,6 +231,11 @@ module HTTParty
         if options[:ssl_version] && http.respond_to?(:ssl_version=)
           http.ssl_version = options[:ssl_version]
         end
+
+        # Include full certificate chain
+        if options[:extra_chain_cert] && options[:p12]
+          http.extra_chain_cert = [p12.certificate] + p12.ca_certs
+        end
       end
     end
   end

--- a/spec/httparty/connection_adapter_spec.rb
+++ b/spec/httparty/connection_adapter_spec.rb
@@ -628,6 +628,15 @@ RSpec.describe HTTParty::ConnectionAdapter do
               expect(subject.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
             end
           end
+
+          context "when using extra_chain_cert and p12 on Ruby 3.0+" do
+            let(:options) { {p12: p12, p12_password: "password", extra_chain_cert: true} }
+
+            it "sets extra_chain_cert on http object" do
+              allow(pkcs12).to receive(:ca_certs).and_return([double("OpenSSL::X509::Certificate")])
+              expect(subject.extra_chain_cert).to eq([cert] + pkcs12.ca_certs)
+            end
+          end
         end
 
         context "when scheme is not https" do

--- a/spec/httparty_spec.rb
+++ b/spec/httparty_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe HTTParty do
     end
   end
 
+  describe "extra_chain_cert" do
+    it 'should set the extra_chain_cert option' do
+      @klass.extra_chain_cert true
+      expect(@klass.default_options[:extra_chain_cert]).to eq(true)
+    end
+  end
+
   describe 'ssl_version' do
     it 'should set the ssl_version content' do
       @klass.ssl_version :SSLv3


### PR DESCRIPTION
## Summary of feature
We ran into an integration where the partner required the full certificate chain included with SSL requests.  Adding this support in HTTParty allows the option to include the full certificate chain utilizing the existing data from the p12 certificate.  This feature has been included in `Net::HTTP` since Ruby **3.0**. I have added a safety check to prevent compatibility issues to ensure it is only accessible when the `extra_chain_cert=` method is available on the Net::HTTP instance.

## Techinical Details
- Added option to determine if the full certificate chain should be included.  Defaults to false
- Add support in connection_adapter to include the full certificate chain if the option is enabled, p12 is being used, and Net::HTTP supports including the certificate chain
- Added specs for both new methods