### PR TITLE
Bugfix: normalize nested hash keys with multipart data

### DIFF
--- a/lib/httparty/hash_conversions.rb
+++ b/lib/httparty/hash_conversions.rb
@@ -54,11 +54,9 @@ module HTTParty
       stack.each do |parent, hash|
         hash.each do |child_key, child_value|
           if child_value.respond_to?(:to_hash)
-            stack << ["#{parent}[#{child_key}]", child_value.to_hash]
+            normalized_keys << normalize_keys("#{parent}[#{child_key}]", child_value).flatten
           elsif child_value.respond_to?(:to_ary)
-            child_value.to_ary.each do |v|
-              normalized_keys << normalize_keys("#{parent}[#{child_key}][]", v).flatten
-            end
+            normalized_keys << normalize_keys("#{parent}[#{child_key}]", child_value)
           else
             normalized_keys << normalize_keys("#{parent}[#{child_key}]", child_value).flatten
           end


### PR DESCRIPTION
While using HTTParty, I encountered a bug already mentioned in #757 .

It seems that normalizing the payload hash for multipart/form-data was not going as expected when the payload contained nested hashes and/or arrays. 

The recursion inside the `normalize_keys` method was not returning the proper result.
This PR should fix this. 