### PR TITLE
Add changelog_uri metadata to gemspec

### DIFF
--- a/httparty.gemspec
+++ b/httparty.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/jnunemaker/httparty"
   s.summary     = 'Makes http fun! Also, makes consuming restful web services dead easy.'
   s.description = 'Makes http fun! Also, makes consuming restful web services dead easy.'
+  s.metadata["changelog_uri"] = 'https://github.com/jnunemaker/httparty/releases'
 
   s.required_ruby_version     = '>= 2.7.0'
 


### PR DESCRIPTION
This adds the changelog_uri to the gemspec metadata,
pointing to the GitHub releases page.
