### PR TITLE
Exclude Authorization header on cors redirects

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -228,6 +228,7 @@ module HTTParty
     def setup_raw_request
       if options[:headers].respond_to?(:to_hash)
         headers_hash = options[:headers].to_hash
+        headers_hash.delete('Authorization') if !send_authorization_header?
       else
         headers_hash = nil
       end

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -1384,6 +1384,25 @@ RSpec.describe HTTParty::Request do
         end
       end
     end
+
+    context "when redirecting to a different host" do
+      before do
+        @redirect = stub_response("", 302)
+        @ok = stub_response('<hash><foo>bar</foo></hash>', 200)
+        @request.options[:headers] = {'Authorization' => 'Bearer xyz'}
+      end
+
+      before(:each) do
+        allow(@http).to receive(:request).and_return(@redirect, @ok)
+      end
+
+      it "should not send Authorization header" do
+        @redirect['location'] = 'http://example.com/v1'
+        @request.perform
+        @request.send(:setup_raw_request)
+        expect(@request.instance_variable_get(:@raw_request)['authorization']).to be_nil
+      end
+    end
   end
 
   context "with POST http method" do


### PR DESCRIPTION
To follow https://fetch.spec.whatwg.org/#http-redirect-fetch `Authorization` header needs to be removed on cors redirects.