### PR TITLE
Fix multipart with files in binary mode and fields including non-ASCII characters

### DIFF
--- a/lib/httparty/request/body.rb
+++ b/lib/httparty/request/body.rb
@@ -83,6 +83,7 @@ module HTTParty
       def content_body(object)
         if file?(object)
           object = (file = object).read
+          object.force_encoding(Encoding::UTF_8) if object.respond_to?(:force_encoding)
           file.rewind if file.respond_to?(:rewind)
         end
 

--- a/spec/httparty/request/body_spec.rb
+++ b/spec/httparty/request/body_spec.rb
@@ -137,6 +137,19 @@ RSpec.describe HTTParty::Request::Body do
           it { is_expected.to eq multipart_params }
 
         end
+
+        context 'when file is binary data and params contain non-ascii characters' do
+          let(:file) { File.open('spec/fixtures/tiny.gif', 'rb') }
+          let(:params) do
+            {
+              user: "Jöhn Döé",
+              enabled: true,
+              avatar: file,
+            }
+          end
+
+          it { expect { subject }.not_to raise_error }
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #821 

```
irb(main):003> HTTParty.post('http://localhost:8888', body: { user: { name: "John Doe", avatar: File.open(path) } })
=> #<HTTParty::Response:0xb070 parsed_response=nil, @response=#<Net::HTTPOK 200 OK readbody=true>, @headers={"content-length" => ["0"]}>
irb(main):004> HTTParty.post('http://localhost:8888', body: { user: { name: "John Doe", avatar: File.open(path, 'rb') } })
=> #<HTTParty::Response:0xf0f0 parsed_response=nil, @response=#<Net::HTTPOK 200 OK readbody=true>, @headers={"content-length" => ["0"]}>
irb(main):005> HTTParty.post('http://localhost:8888', body: { user: { name: "Jöhñ Ďœ", avator: File.open(path) } })
=> #<HTTParty::Response:0x10ca0 parsed_response=nil, @response=#<Net::HTTPOK 200 OK readbody=true>, @headers={"content-length" => ["0"]}>
irb(main):006> HTTParty.post('http://localhost:8888', body: { user: { name: "Jöhñ Ďœ", avator: File.open(path, 'rb') } })
=> #<HTTParty::Response:0x14d20 parsed_response=nil, @response=#<Net::HTTPOK 200 OK readbody=true>, @headers={"content-length" => ["0"]}>
```

I think this is safe because [`String#force_encoding`](https://docs.ruby-lang.org/en/master/String.html#method-i-force_encoding) says it "does not change the underlying bytes". Also [the default mode for Files](https://docs.ruby-lang.org/en/master/File.html#class-File-label-Data+Mode) in Ruby is text data which sets the default external encoding to `Encoding::UTF_8`.