### PR TITLE
Expose verify_callback option from Net::HTTP

### DIFF
--- a/lib/httparty/connection_adapter.rb
+++ b/lib/httparty/connection_adapter.rb
@@ -50,6 +50,7 @@ module HTTParty
   # * :+pem+: contains pem client certificate data. see method 'attach_ssl_certificates'
   # * :+p12+: contains PKCS12 client client certificate data.  see method 'attach_ssl_certificates'
   # * :+verify+: verify the server’s certificate against the ca certificate.
+  # * :+verify_callback+: a Proc that will be called to verify the server’s certificate. see method 'attach_ssl_certificates'
   # * :+verify_peer+: set to false to turn off server verification but still send client certificate
   # * :+ssl_ca_file+: see HTTParty::ClassMethods.ssl_ca_file.
   # * :+ssl_ca_path+: see HTTParty::ClassMethods.ssl_ca_path.
@@ -225,6 +226,10 @@ module HTTParty
         if options[:ssl_ca_path]
           http.ca_path = options[:ssl_ca_path]
           http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        end
+
+        if options[:verify_callback]
+          http.verify_callback = options[:verify_callback]
         end
 
         # This is only Ruby 1.9+

--- a/spec/httparty/connection_adapter_spec.rb
+++ b/spec/httparty/connection_adapter_spec.rb
@@ -661,6 +661,33 @@ RSpec.describe HTTParty::ConnectionAdapter do
           it { expect(subject.port).to be 443 }
         end
       end
+
+      context "when providing verify_callback" do
+        let(:verify_callback) { double("verify_callback") }
+        let(:options) { {verify_callback: verify_callback} }
+
+        context "when scheme is https" do
+          let(:uri) { URI 'https://google.com' }
+
+          it "uses the provided verify_callback" do
+            expect(subject.verify_callback).to be verify_callback
+          end
+        end
+
+        context "when scheme is not https" do
+          let(:uri) { URI 'http://google.com' }
+          let(:http) { Net::HTTP.new(uri) }
+
+          before do
+            allow(Net::HTTP).to receive_messages(new: http)
+            expect(http).not_to receive(:verify_callback=)
+          end
+
+          it "has no verify_callback " do
+            expect(subject.verify_callback).to be_nil
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

Currently when calling an API using HTTParty and facing a certificate error, we see a log like this `OpenSSL::SSL::SSLError, SSL_connect returned=1 errno=0 peeraddr=<ip_address>:443 state=error: certificate verify failed (unable to get issuer certificate)`. 

In a bid to get more verbose logs that specify which certificate is failing verification, we found a thread [here](https://github.com/ruby/openssl/issues/800) that suggested using the `verify_callback` option of `Net::HTTP` that acts as a hook for adding custom logic like logging more details about which cert failed and the cert issuer etc.

This is an example implementation we have for the block which enables us to get more logs when an SSL verification failure happens:
```ruby
def verify_callback_lambda
    lambda do |verify_ok, store_context|
      unless verify_ok
        failed_cert = store_context.current_cert
        failed_cert_reason = format('%d: %s', store_context.error, store_context.error_string)
        error_message = 'SSL verification failed for certificate:  ' \
                        "subject: #{failed_cert.subject} " \
                        "issuer: #{failed_cert.issuer} " \
                        "error code: #{failed_cert_reason}"
        log(error_message)
      end
      verify_ok
    end
  end
```

### Technical implementation
It is a simple addition to the list of https options we are passing in through `attach_ssl_certificates` method