### PR TITLE
feat: set default content type when processing body

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -242,11 +242,8 @@ module HTTParty
           force_multipart: options[:multipart]
         )
 
-        if body.multipart?
-          content_type = "multipart/form-data; boundary=#{body.boundary}"
-          @raw_request['Content-Type'] = content_type
-        end
         @raw_request.body = body.call
+        @raw_request['Content-Type'] ||= body.content_type
       end
 
       @raw_request.instance_variable_set(:@decode_content, decompress_content?)


### PR DESCRIPTION
httparty does properly set multipart content type when dealing with files or multipart url bodies. There was no default for urlencoded.

net-http 0.7.0 stops defaulting content type to x-www-form-urlencoded ([net-http PR #207](https://github.com/ruby/net-http/pull/207), issue [#205](https://github.com/ruby/net-http/issues/205)). HTTParty encodes body with urlencode by default, but does not set content-type. HTTParty's default behavior of urlencoding needs to set content type. 

changes in this pr:
- default content type is set when implicitly encoding body as urlencode, as before with multipart
- content type default is not used when set or when using custom query_string_normalizer.

If you use custom query_string_normalizer, return content_type as a second argument or pass a `Content-Type` header