### PR TITLE
set Content-Type for Hash body in requests

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -245,6 +245,8 @@ module HTTParty
         if body.multipart?
           content_type = "multipart/form-data; boundary=#{body.boundary}"
           @raw_request['Content-Type'] = content_type
+        elsif options[:body].respond_to?(:to_hash) && !@raw_request['Content-Type']
+          @raw_request['Content-Type'] = 'application/x-www-form-urlencoded'
         end
         @raw_request.body = body.call
       end

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -378,6 +378,29 @@ RSpec.describe HTTParty::Request do
         end
       end
     end
+
+    context "when body is a Hash" do
+      subject(:headers) do
+        @request.send(:setup_raw_request)
+        headers = @request.instance_variable_get(:@raw_request).each_header.to_a
+        Hash[*headers.flatten]
+      end
+
+      it "sets header Content-Type: application/x-www-form-urlencoded" do
+        @request.options[:body] = { foo: 'bar' }
+
+        expect(headers['content-type']).to eq('application/x-www-form-urlencoded')
+      end
+
+      context "and header Content-Type is provided" do
+        it "does not overwrite the provided Content-Type" do
+          @request.options[:body] = { foo: 'bar' }
+          @request.options[:headers] = { 'Content-Type' => 'application/json' }
+
+          expect(headers['content-type']).to eq('application/json')
+        end
+      end
+    end
   end
 
   describe 'http' do


### PR DESCRIPTION
Added logic to automatically set the Content-Type to 'application/x-www-form-urlencoded' when the request body is a Hash and no Content-Type is specified. Updated tests to verify this behavior and ensure that provided Content-Types are not overwritten.

refs [Informative] net-http 0.7.0 indirectly breaks HTTParty - default content-type removed. Fixes #826