### PR TITLE
feat: stream multipart file uploads to reduce memory usage

### DIFF
--- a/lib/httparty/request.rb
+++ b/lib/httparty/request.rb
@@ -248,7 +248,14 @@ module HTTParty
         elsif options[:body].respond_to?(:to_hash) && !@raw_request['Content-Type']
           @raw_request['Content-Type'] = 'application/x-www-form-urlencoded'
         end
-        @raw_request.body = body.call
+
+        if body.streaming? && options[:stream_body] != false
+          stream = body.to_stream
+          @raw_request.body_stream = stream
+          @raw_request['Content-Length'] = stream.size.to_s
+        else
+          @raw_request.body = body.call
+        end
       end
 
       @raw_request.instance_variable_set(:@decode_content, decompress_content?)

--- a/lib/httparty/request/streaming_multipart_body.rb
+++ b/lib/httparty/request/streaming_multipart_body.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+module HTTParty
+  class Request
+    class StreamingMultipartBody
+      NEWLINE = "\r\n"
+      CHUNK_SIZE = 64 * 1024 # 64 KB chunks
+
+      def initialize(parts, boundary)
+        @parts = parts
+        @boundary = boundary
+        @part_index = 0
+        @state = :header
+        @current_file = nil
+        @header_buffer = nil
+        @header_offset = 0
+        @footer_sent = false
+      end
+
+      def size
+        @size ||= calculate_size
+      end
+
+      def read(length = nil, outbuf = nil)
+        outbuf = outbuf ? outbuf.replace(''.b) : ''.b
+
+        return read_all(outbuf) if length.nil?
+
+        while outbuf.bytesize < length
+          chunk = read_chunk(length - outbuf.bytesize)
+          break if chunk.nil?
+          outbuf << chunk
+        end
+
+        outbuf.empty? ? nil : outbuf
+      end
+
+      def rewind
+        @part_index = 0
+        @state = :header
+        @current_file = nil
+        @header_buffer = nil
+        @header_offset = 0
+        @footer_sent = false
+        @parts.each do |_key, value, _is_file|
+          value.rewind if value.respond_to?(:rewind)
+        end
+      end
+
+      private
+
+      def read_all(outbuf)
+        while (chunk = read_chunk(CHUNK_SIZE))
+          outbuf << chunk
+        end
+        outbuf.empty? ? nil : outbuf
+      end
+
+      def read_chunk(max_length)
+        loop do
+          return nil if @part_index >= @parts.size && @footer_sent
+
+          if @part_index >= @parts.size
+            @footer_sent = true
+            return "--#{@boundary}--#{NEWLINE}".b
+          end
+
+          key, value, is_file = @parts[@part_index]
+
+          case @state
+          when :header
+            chunk = read_header_chunk(key, value, is_file, max_length)
+            return chunk if chunk
+
+          when :body
+            chunk = read_body_chunk(value, is_file, max_length)
+            return chunk if chunk
+
+          when :newline
+            @state = :header
+            @part_index += 1
+            return NEWLINE.b
+          end
+        end
+      end
+
+      def read_header_chunk(key, value, is_file, max_length)
+        if @header_buffer.nil?
+          @header_buffer = build_part_header(key, value, is_file)
+          @header_offset = 0
+        end
+
+        remaining = @header_buffer.bytesize - @header_offset
+        if remaining > 0
+          chunk_size = [remaining, max_length].min
+          chunk = @header_buffer.byteslice(@header_offset, chunk_size)
+          @header_offset += chunk_size
+          return chunk
+        end
+
+        @header_buffer = nil
+        @header_offset = 0
+        @state = :body
+        nil
+      end
+
+      def read_body_chunk(value, is_file, max_length)
+        if is_file
+          chunk = read_file_chunk(value, max_length)
+          if chunk
+            return chunk
+          else
+            @current_file = nil
+            @state = :newline
+            return nil
+          end
+        else
+          @state = :newline
+          return value.to_s.b
+        end
+      end
+
+      def read_file_chunk(file, max_length)
+        chunk_size = [max_length, CHUNK_SIZE].min
+        chunk = file.read(chunk_size)
+        return nil if chunk.nil?
+        chunk.force_encoding(Encoding::BINARY) if chunk.respond_to?(:force_encoding)
+        chunk
+      end
+
+      def build_part_header(key, value, is_file)
+        header = "--#{@boundary}#{NEWLINE}".b
+        header << %(Content-Disposition: form-data; name="#{key}").b
+        if is_file
+          header << %(; filename="#{file_name(value).gsub(/["\r\n]/, replacement_table)}").b
+          header << NEWLINE.b
+          header << "Content-Type: #{content_type(value)}#{NEWLINE}".b
+        end
+        header << NEWLINE.b
+        header
+      end
+
+      def calculate_size
+        total = 0
+        @parts.each do |key, value, is_file|
+          total += build_part_header(key, value, is_file).bytesize
+          total += content_size(value, is_file)
+          total += NEWLINE.bytesize
+        end
+        total += "--#{@boundary}--#{NEWLINE}".bytesize
+        total
+      end
+
+      def content_size(value, is_file)
+        if is_file
+          if value.respond_to?(:size)
+            value.size
+          elsif value.respond_to?(:stat)
+            value.stat.size
+          else
+            value.read.bytesize.tap { value.rewind }
+          end
+        else
+          value.to_s.b.bytesize
+        end
+      end
+
+      def content_type(object)
+        return object.content_type if object.respond_to?(:content_type)
+        require 'mini_mime'
+        mime = MiniMime.lookup_by_filename(object.path)
+        mime ? mime.content_type : 'application/octet-stream'
+      end
+
+      def file_name(object)
+        object.respond_to?(:original_filename) ? object.original_filename : File.basename(object.path)
+      end
+
+      def replacement_table
+        @replacement_table ||= {
+          '"'  => '%22',
+          "\r" => '%0D',
+          "\n" => '%0A'
+        }.freeze
+      end
+    end
+  end
+end

--- a/spec/httparty/request/streaming_multipart_body_spec.rb
+++ b/spec/httparty/request/streaming_multipart_body_spec.rb
@@ -1,0 +1,138 @@
+require 'spec_helper'
+require 'tempfile'
+
+RSpec.describe HTTParty::Request::StreamingMultipartBody do
+  let(:boundary) { '------------------------c772861a5109d5ef' }
+
+  describe '#read' do
+    context 'with a simple file' do
+      let(:file) { File.open('spec/fixtures/tiny.gif', 'rb') }
+      let(:parts) { [['avatar', file, true]] }
+      subject { described_class.new(parts, boundary) }
+
+      after { file.close }
+
+      it 'streams the complete multipart body' do
+        result = subject.read
+        expect(result.encoding).to eq(Encoding::BINARY)
+        expect(result).to include("--#{boundary}")
+        expect(result).to include('Content-Disposition: form-data; name="avatar"')
+        expect(result).to include('filename="tiny.gif"')
+        expect(result).to include('Content-Type: image/gif')
+        expect(result).to include("GIF89a") # GIF file header
+        expect(result).to end_with("--#{boundary}--\r\n")
+      end
+
+      it 'returns same content as non-streaming body' do
+        # Create equivalent Body for comparison
+        body = HTTParty::Request::Body.new({ avatar: File.open('spec/fixtures/tiny.gif', 'rb') })
+        allow(HTTParty::Request::MultipartBoundary).to receive(:generate).and_return(boundary)
+
+        streaming_result = subject.read
+        non_streaming_result = body.call
+
+        expect(streaming_result).to eq(non_streaming_result)
+      end
+    end
+
+    context 'with mixed file and text fields' do
+      let(:file) { File.open('spec/fixtures/tiny.gif', 'rb') }
+      let(:parts) do
+        [
+          ['user[avatar]', file, true],
+          ['user[name]', 'John Doe', false],
+          ['user[active]', 'true', false]
+        ]
+      end
+      subject { described_class.new(parts, boundary) }
+
+      after { file.close }
+
+      it 'streams all parts correctly' do
+        result = subject.read
+        expect(result).to include('name="user[avatar]"')
+        expect(result).to include('name="user[name]"')
+        expect(result).to include('John Doe')
+        expect(result).to include('name="user[active]"')
+        expect(result).to include('true')
+      end
+    end
+
+    context 'reading in chunks' do
+      let(:file) { File.open('spec/fixtures/tiny.gif', 'rb') }
+      let(:parts) { [['avatar', file, true]] }
+      subject { described_class.new(parts, boundary) }
+
+      after { file.close }
+
+      it 'reads correctly in small chunks' do
+        chunks = []
+        while (chunk = subject.read(10))
+          chunks << chunk
+        end
+        full_result = chunks.join
+
+        subject.rewind
+        single_read = subject.read
+
+        expect(full_result).to eq(single_read)
+      end
+
+      it 'returns nil when exhausted' do
+        subject.read # Read all
+        expect(subject.read).to be_nil
+      end
+    end
+  end
+
+  describe '#size' do
+    let(:file) { File.open('spec/fixtures/tiny.gif', 'rb') }
+    let(:parts) { [['avatar', file, true]] }
+    subject { described_class.new(parts, boundary) }
+
+    after { file.close }
+
+    it 'returns the correct total size' do
+      size = subject.size
+      content = subject.read
+      expect(size).to eq(content.bytesize)
+    end
+  end
+
+  describe '#rewind' do
+    let(:file) { File.open('spec/fixtures/tiny.gif', 'rb') }
+    let(:parts) { [['avatar', file, true]] }
+    subject { described_class.new(parts, boundary) }
+
+    after { file.close }
+
+    it 'allows re-reading the stream' do
+      first_read = subject.read
+      subject.rewind
+      second_read = subject.read
+      expect(first_read).to eq(second_read)
+    end
+  end
+
+  describe 'memory efficiency' do
+    it 'does not load entire file into memory at once' do
+      # Create a larger temp file
+      tempfile = Tempfile.new(['large', '.bin'])
+      tempfile.write('x' * (1024 * 1024)) # 1 MB
+      tempfile.rewind
+
+      parts = [['file', tempfile, true]]
+      stream = described_class.new(parts, boundary)
+
+      # Read in small chunks - this should work without allocating 1MB at once
+      chunks_read = 0
+      while stream.read(1024)
+        chunks_read += 1
+      end
+
+      expect(chunks_read).to be > 100 # Should have read many chunks
+      tempfile.close
+      tempfile.unlink
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fixes excessive memory usage when uploading files via multipart form data
- Previously, uploading a 10 MB file consumed ~40 MB of memory (4x the file size)
- Now files are streamed in 64 KB chunks, drastically reducing memory footprint

### Root Cause

The issue was in `Request::Body#generate_multipart` which:
1. Read entire file into memory with `file.read`
2. Concatenated it into a growing string with `<<`
3. Caused multiple string reallocations

### Solution

Introduced `StreamingMultipartBody` class that implements an IO-like interface (`read`, `size`, `rewind`) which Net::HTTP can use via `body_stream`. Files are read in chunks on-demand instead of being loaded entirely into memory.

### Changes

| File | Description |
|------|-------------|
| `lib/httparty/request/streaming_multipart_body.rb` | New streaming IO wrapper |
| `lib/httparty/request/body.rb` | Added `streaming?`, `to_stream`, `prepared_parts` |
| `lib/httparty/request.rb` | Use `body_stream` for file uploads |

### Usage

Streaming is **automatic** for file uploads. To opt-out:

```ruby
HTTParty.post(url, body: { file: File.open('large.bin') }, stream_body: false)
```

## Test plan

- [x] Added unit tests for `StreamingMultipartBody` (read, size, rewind, chunking)
- [x] Added unit tests for `Body#streaming?` and `Body#to_stream`
- [x] Added integration tests verifying `body_stream` is used for file uploads
- [x] Added test verifying streaming produces identical content to non-streaming
- [x] All 760 existing tests pass
- [x] All 186 Cucumber scenarios pass

Fixes issue reported in: https://gist.github.com/janko/238bbcc78b369ce3438365e5507bc671

🤖 Generated with [Claude Code](https://claude.com/claude-code)