### PR TITLE
fix: prevent SSRF via absolute URL bypassing base_uri

### DIFF
--- a/lib/httparty/exceptions.rb
+++ b/lib/httparty/exceptions.rb
@@ -59,4 +59,8 @@ module HTTParty
 
   # Exception that is raised when common network errors occur.
   class NetworkError < Foul; end
+
+  # Exception that is raised when an absolute URI is used that doesn't match
+  # the configured base_uri, which could indicate an SSRF attempt.
+  class UnsafeURIError < Foul; end
 end

--- a/spec/support/stub_response.rb
+++ b/spec/support/stub_response.rb
@@ -29,7 +29,9 @@ module HTTParty
 
     def stub_response(body, code = '200')
       code = code.to_s
-      @request.options[:base_uri] ||= 'http://localhost'
+      # Only set default base_uri if path is relative (has no host)
+      # This avoids triggering URI safety validation for absolute URLs in tests
+      @request.options[:base_uri] ||= 'http://localhost' if @request.path.relative?
       unless defined?(@http) && @http
         @http = Net::HTTP.new('localhost', 80)
         allow(@request).to receive(:http).and_return(@http)


### PR DESCRIPTION
When base_uri is configured and a path argument contains an absolute URL with a different host, HTTParty now raises UnsafeURIError instead of sending the request (and any configured headers/credentials) to the unintended host.

This prevents Server-Side Request Forgery (SSRF) attacks where an attacker controlling the path value could redirect requests to malicious servers and capture API keys or other sensitive headers.

The validation can be bypassed with `skip_uri_validation: true` for legitimate use cases. Redirects are not validated to allow normal redirect flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)