### PR TITLE
Add trailing clrf when building header for non-file parts.

### DIFF
--- a/lib/httparty/request/streaming_multipart_body.rb
+++ b/lib/httparty/request/streaming_multipart_body.rb
@@ -135,6 +135,8 @@ module HTTParty
           header << %(; filename="#{file_name(value).gsub(/["\r\n]/, replacement_table)}").b
           header << NEWLINE.b
           header << "Content-Type: #{content_type(value)}#{NEWLINE}".b
+        else
+          header << NEWLINE.b
         end
         header << NEWLINE.b
         header

--- a/spec/httparty/request_spec.rb
+++ b/spec/httparty/request_spec.rb
@@ -282,14 +282,14 @@ RSpec.describe HTTParty::Request do
         allow(HTTParty::Request::MultipartBoundary).to receive(:generate).and_return('test-boundary-123')
 
         # Get streaming content
-        request1 = HTTParty::Request.new(Net::HTTP::Post, 'http://api.foo.com/v1', body: { avatar: file })
+        request1 = HTTParty::Request.new(Net::HTTP::Post, 'http://api.foo.com/v1', body: { avatar: file, first_name: "John" })
         request1.send(:setup_raw_request)
         streaming_content = request1.instance_variable_get(:@raw_request).body_stream.read
 
         file.rewind
 
         # Get non-streaming content
-        request2 = HTTParty::Request.new(Net::HTTP::Post, 'http://api.foo.com/v1', body: { avatar: file }, stream_body: false)
+        request2 = HTTParty::Request.new(Net::HTTP::Post, 'http://api.foo.com/v1', body: { avatar: file, first_name: "John" }, stream_body: false)
         request2.send(:setup_raw_request)
         non_streaming_content = request2.instance_variable_get(:@raw_request).body
 


### PR DESCRIPTION
When building a `StreamingMultipartBody`, the streaming body should produce same content as non-streamining.  The following example shows the header for the `first_name` part (a non-file part) is missing a clrf before the part's content starts.  I think this explains the 400 error described in #832 .

==== Before: no extra blank line between `"first_name"` and `John`  ====
```
--test-boundary-123
Content-Disposition: form-data; name="avatar"; filename="tiny.gif" Content-Type: image/gif

GIF89a,;
--test-boundary-123
Content-Disposition: form-data; name="first_name"
John
--test-boundary-123
```

The fix adds a trailing clrf to a non-file part's header:

==== After: notice the extra blank line between `"first_name"` and `John` ====
```
--test-boundary-123
Content-Disposition: form-data; name="avatar"; filename="tiny.gif" Content-Type: image/gif

GIF89a,;
--test-boundary-123
Content-Disposition: form-data; name="first_name"

John
--test-boundary-123
```

The Before/After outputs are generated by adding `puts streaming_content` to the updated `streaming body produces same content as non-streaming` test.