### PR TITLE
Use MultiXML constant to fix deprecation warning from multi_xml 0.9+

### DIFF
--- a/lib/httparty/parser.rb
+++ b/lib/httparty/parser.rb
@@ -119,7 +119,7 @@ module HTTParty
 
     def xml
       require 'multi_xml'
-      MultiXml.parse(body)
+      (defined?(MultiXML) ? MultiXML : MultiXml).parse(body)
     end
 
     UTF8_BOM = "\xEF\xBB\xBF"

--- a/spec/httparty/parser_spec.rb
+++ b/spec/httparty/parser_spec.rb
@@ -165,8 +165,9 @@ RSpec.describe HTTParty::Parser do
       HTTParty::Parser.new('body', nil)
     end
 
-    it "parses xml with MultiXml" do
-      expect(MultiXml).to receive(:parse).with('body')
+    it "parses xml with MultiXML" do
+      xml_parser = defined?(MultiXML) ? MultiXML : MultiXml
+      expect(xml_parser).to receive(:parse).with('body')
       subject.send(:xml)
     end
 

--- a/spec/httparty/parser_spec.rb
+++ b/spec/httparty/parser_spec.rb
@@ -165,9 +165,15 @@ RSpec.describe HTTParty::Parser do
       HTTParty::Parser.new('body', nil)
     end
 
-    it "parses xml with MultiXML" do
-      xml_parser = defined?(MultiXML) ? MultiXML : MultiXml
-      expect(xml_parser).to receive(:parse).with('body')
+    it "parses xml with MultiXML when available" do
+      stub_const('MultiXML', double)
+      expect(MultiXML).to receive(:parse).with('body')
+      subject.send(:xml)
+    end
+
+    it "falls back to MultiXml when MultiXML is unavailable" do
+      hide_const('MultiXML') if defined?(MultiXML)
+      expect(MultiXml).to receive(:parse).with('body')
       subject.send(:xml)
     end
 


### PR DESCRIPTION
multi_xml 0.9.0 renamed the top-level constant from \`MultiXml\` to \`MultiXML\` and made the old name a deprecated shim that emits a warning on every method call:

\`\`\`
The MultiXml constant is deprecated and will be removed in v1.0. Use MultiXML instead.
\`\`\`

This uses \`defined?(MultiXML)\` to prefer the new constant when available (multi_xml >= 0.9), falling back to \`MultiXml\` on older versions. No minimum version bump required — the fix is fully backward compatible.