### PR TITLE
Remove JSON `:quirks_mode` method from `:json` method

### DIFF
--- a/lib/httparty/parser.rb
+++ b/lib/httparty/parser.rb
@@ -126,7 +126,7 @@ module HTTParty
 
     def json
       require 'json'
-      JSON.parse(body, :quirks_mode => true, :allow_nan => true)
+      JSON.parse(body, :allow_nan => true)
     end
 
     def csv

--- a/spec/httparty/parser_spec.rb
+++ b/spec/httparty/parser_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe HTTParty::Parser do
     end
 
     it "parses json with JSON" do
-      expect(JSON).to receive(:parse).with('body', :quirks_mode => true, :allow_nan => true)
+      expect(JSON).to receive(:parse).with('body', :allow_nan => true)
       subject.send(:json)
     end
 


### PR DESCRIPTION
As of JSON 3.0.0, the `quirks_mode` method has been removed and no longer supported. The original behavior has the following code that was hardcoded:

```ruby
JSON.parse(body, :quirks_mode => true, :allow_nan => true)
```

so on json >= 3.0 every JSON response HTTParty tries to parse raises:

```
ArgumentError: unknown keyword: quirks_mode
```

This breaks any app that upgrades to json 3.x while still using HTTParty for JSON APIs.